### PR TITLE
Add Space ROS-based Docker setup

### DIFF
--- a/docker.spaceros/Dockerfile
+++ b/docker.spaceros/Dockerfile
@@ -1,0 +1,61 @@
+FROM osrf/space-ros:latest
+
+RUN python3 -m pip install opencv-python omegaconf hydra-core
+
+# setup timezone
+RUN echo 'Etc/UTC' | sudo tee /etc/timezone && \
+    sudo ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    sudo apt-get update && \
+    sudo apt-get install -q -y --no-install-recommends tzdata apt-utils && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN sudo apt-get update && sudo apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    curl \
+    libglib2.0-0 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO humble
+
+# install ros2 packages
+RUN sudo apt-get update && sudo apt-get install -y \
+    ros-humble-ros-core=0.10.0-1* \
+    gdal-bin \
+    libgdal-dev \
+    ros-humble-vision-msgs \
+    ros-humble-tf2-msgs \
+    g++ \
+    wget \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# install Isaac Sim dependencies
+RUN sudo apt-get update && \
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq --no-install-recommends \
+    libgl1 \
+    libglu1 \
+    libxt-dev \
+    ffmpeg && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install skyfield zfpy numba gdown
+RUN python3 -m pip install gdal==$(gdal-config --version)
+
+# isaac ros2_bridge config
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/isaac-sim/exts/omni.isaac.ros2_bridge/humble/lib
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+
+# setup entrypoint
+COPY ./entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/docker.spaceros/Dockerfile.bundle_isaac_sim
+++ b/docker.spaceros/Dockerfile.bundle_isaac_sim
@@ -2,14 +2,11 @@ FROM nvcr.io/nvidia/isaac-sim:2023.1.1 AS isaac-sim
 FROM osrf/space-ros:latest
 
 # copy Isaac Sim into the base image
-ARG ISAAC_SIM_PATH="${HOME_DIR}/isaac-sim"
+ARG ISAAC_SIM_PATH="/isaac-sim"
 ENV ISAAC_SIM_PYTHON="${ISAAC_SIM_PATH}/python.sh"
 COPY --from=isaac-sim --chown=${USERNAME}:${USERNAME} /isaac-sim "${ISAAC_SIM_PATH}"
 COPY --from=isaac-sim --chown=${USERNAME}:${USERNAME} /root/.nvidia-omniverse/config "${HOME_DIR}/.nvidia-omniverse/config"
 COPY --from=isaac-sim /etc/vulkan/icd.d/nvidia_icd.json /etc/vulkan/icd.d/nvidia_icd.json
-RUN ISAAC_SIM_VERSION="$(cut -d'-' -f1 < "${ISAAC_SIM_PATH}/VERSION")" && \
-    echo -e "\n# Isaac Sim ${ISAAC_SIM_VERSION}" >> /ros_entrypoint.sh && \
-    echo "export ISAAC_SIM_PATH=\"${ISAAC_SIM_PATH}\"" >> /ros_entrypoint.sh
 
 RUN ${ISAAC_SIM_PYTHON} -m pip install opencv-python omegaconf hydra-core
 

--- a/docker.spaceros/Dockerfile.bundle_isaac_sim
+++ b/docker.spaceros/Dockerfile.bundle_isaac_sim
@@ -1,0 +1,72 @@
+FROM nvcr.io/nvidia/isaac-sim:2023.1.1 AS isaac-sim
+FROM osrf/space-ros:latest
+
+# copy Isaac Sim into the base image
+ARG ISAAC_SIM_PATH="${HOME_DIR}/isaac-sim"
+ENV ISAAC_SIM_PYTHON="${ISAAC_SIM_PATH}/python.sh"
+COPY --from=isaac-sim --chown=${USERNAME}:${USERNAME} /isaac-sim "${ISAAC_SIM_PATH}"
+COPY --from=isaac-sim --chown=${USERNAME}:${USERNAME} /root/.nvidia-omniverse/config "${HOME_DIR}/.nvidia-omniverse/config"
+COPY --from=isaac-sim /etc/vulkan/icd.d/nvidia_icd.json /etc/vulkan/icd.d/nvidia_icd.json
+RUN ISAAC_SIM_VERSION="$(cut -d'-' -f1 < "${ISAAC_SIM_PATH}/VERSION")" && \
+    echo -e "\n# Isaac Sim ${ISAAC_SIM_VERSION}" >> /ros_entrypoint.sh && \
+    echo "export ISAAC_SIM_PATH=\"${ISAAC_SIM_PATH}\"" >> /ros_entrypoint.sh
+
+RUN ${ISAAC_SIM_PYTHON} -m pip install opencv-python omegaconf hydra-core
+
+# setup timezone
+RUN echo 'Etc/UTC' | sudo tee /etc/timezone && \
+    sudo ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    sudo apt-get update && \
+    sudo apt-get install -q -y --no-install-recommends tzdata apt-utils && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN sudo apt-get update && sudo apt-get install -q -y \
+    dirmngr \
+    gnupg2 \
+    curl \
+    libglib2.0-0 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO humble
+
+# install ros2 packages
+RUN sudo apt-get update && sudo apt-get install -y \
+    ros-humble-ros-core=0.10.0-1* \
+    gdal-bin \
+    libgdal-dev \
+    ros-humble-vision-msgs \
+    ros-humble-tf2-msgs \
+    g++ \
+    wget \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# install Isaac Sim dependencies
+RUN sudo apt-get update && \
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq --no-install-recommends \
+    libgl1 \
+    libglu1 \
+    libxt-dev \
+    ffmpeg && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+RUN ${ISAAC_SIM_PYTHON} -m pip install skyfield zfpy numba gdown
+RUN ${ISAAC_SIM_PYTHON} -m pip install gdal==$(gdal-config --version)
+
+# isaac ros2_bridge config
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/isaac-sim/exts/omni.isaac.ros2_bridge/humble/lib
+ENV RMW_IMPLEMENTATION=rmw_fastrtps_cpp
+
+# setup entrypoint
+COPY ./entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/docker.spaceros/build.sh
+++ b/docker.spaceros/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" &>/dev/null && pwd)"
+TAG="isaac-sim-omnilrs"
+DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
+
+# Check if Isaac Sim can be pulled to determine whether to bundle Isaac Sim or rely on a local installation
+ISAAC_SIM_IMAGE_NAME="${ISAAC_SIM_IMAGE_NAME:-"nvcr.io/nvidia/isaac-sim"}"
+ISAAC_SIM_IMAGE_TAG="${ISAAC_SIM_IMAGE_TAG:-"2023.1.1"}"
+if ${WITH_SUDO} docker pull "${ISAAC_SIM_IMAGE_NAME}:${ISAAC_SIM_IMAGE_TAG}" &>/dev/null; then
+    DOCKERFILE+=".bundle_isaac_sim"
+else
+    >&2 echo -e "\033[1;33m[WARN] This system is not logged into the NVIDIA NGC registry to pull '${ISAAC_SIM_IMAGE_NAME}:${ISAAC_SIM_IMAGE_TAG}' image"
+    >&2 echo -e "[WARN] Local installation of Isaac Sim will have to be mounted as a volume when running this demo image\033[0m"
+fi
+
+DOCKER_BUILD_CMD=(docker build "${SCRIPT_DIR}" --tag ${TAG} --file "${DOCKERFILE}")
+
+echo -e "\033[0;32m${DOCKER_BUILD_CMD[*]}\033[0m" | xargs
+
+# shellcheck disable=SC2068
+exec ${DOCKER_BUILD_CMD[*]}

--- a/docker.spaceros/entrypoint.sh
+++ b/docker.spaceros/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Setup the Space ROS environment
+source "${SPACEROS_DIR}/install/setup.bash"
+export IKOS_SCAN_NOTIFIER_FILES="" # make ikos create .ikosbin files for compiled packages
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+cd /workspace/omnilrs
+exec "$@"

--- a/docker.spaceros/run.sh
+++ b/docker.spaceros/run.sh
@@ -3,13 +3,10 @@ xhost +
 
 VOLUMES=(
     "${PWD}:/workspace/omnilrs:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/cache/kit:/home/spaceros-user/isaac-sim/kit/cache:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/cache/ov:/home/spaceros-user/.cache/ov:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/cache/pip:/home/spaceros-user/.cache/pip:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/cache/glcache:/home/spaceros-user/.cache/nvidia/GLCache:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/cache/computecache:/home/spaceros-user/.nv/ComputeCache:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/logs:/home/spaceros-user/.nvidia-omniverse/logs:rw"
-    "${HOME}/docker/omnilrs/isaac-sim/data:/home/spaceros-user/.local/share/ov/data:rw"
+    "${HOME}/docker/cache/omnilrs/isaac-sim/computecache:/home/spaceros-user/.nv/ComputeCache:rw"
+    "${HOME}/docker/cache/omnilrs/isaac-sim/glcache:/home/spaceros-user/.cache/nvidia/GLCache:rw"
+    "${HOME}/docker/cache/omnilrs/isaac-sim/kit:/isaac-sim/kit/cache:rw"
+    "${HOME}/docker/cache/omnilrs/isaac-sim/ov:/home/spaceros-user/.cache/ov:rw"
 )
 # Create cache directories with appropriate permissions for the user inside the container
 for VOLUME in "${VOLUMES[@]}"; do
@@ -19,7 +16,7 @@ for VOLUME in "${VOLUMES[@]}"; do
         chmod 777 "${HOST_DIR}"
     fi
 done
-find "${DEMO_DIR}" -exec bash -c 'p=$(stat -c "%a" "$0"); op=${p:0:1}; chmod "${op}${op}${op}" "$0" 2>/dev/null' {} \; 2>/dev/null || :
+find "${PWD}" -exec bash -c 'p=$(stat -c "%a" "$0"); op=${p:0:1}; chmod "${op}${op}${op}" "$0" 2>/dev/null' {} \; 2>/dev/null || :
 
 docker run --name isaac-sim-omnilrs-container -it --gpus all -e "ACCEPT_EULA=Y" --rm --network=host --ipc=host \
 -v $HOME/.Xauthority:/root/.Xauthority \

--- a/docker.spaceros/run.sh
+++ b/docker.spaceros/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+xhost +
+
+VOLUMES=(
+    "${PWD}:/workspace/omnilrs:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/cache/kit:/home/spaceros-user/isaac-sim/kit/cache:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/cache/ov:/home/spaceros-user/.cache/ov:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/cache/pip:/home/spaceros-user/.cache/pip:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/cache/glcache:/home/spaceros-user/.cache/nvidia/GLCache:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/cache/computecache:/home/spaceros-user/.nv/ComputeCache:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/logs:/home/spaceros-user/.nvidia-omniverse/logs:rw"
+    "${HOME}/docker/omnilrs/isaac-sim/data:/home/spaceros-user/.local/share/ov/data:rw"
+)
+# Create cache directories with appropriate permissions for the user inside the container
+for VOLUME in "${VOLUMES[@]}"; do
+    HOST_DIR="${VOLUME%%:*}"
+    if [[ "${HOST_DIR}" == *cache* ]]; then
+        mkdir -p "${HOST_DIR}"
+        chmod 777 "${HOST_DIR}"
+    fi
+done
+find "${DEMO_DIR}" -exec bash -c 'p=$(stat -c "%a" "$0"); op=${p:0:1}; chmod "${op}${op}${op}" "$0" 2>/dev/null' {} \; 2>/dev/null || :
+
+docker run --name isaac-sim-omnilrs-container -it --gpus all -e "ACCEPT_EULA=Y" --rm --network=host --ipc=host \
+-v $HOME/.Xauthority:/root/.Xauthority \
+-e DISPLAY \
+-e "PRIVACY_CONSENT=Y" \
+"${VOLUMES[@]/#/"-v="}" \
+isaac-sim-omnilrs:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN /isaac-sim/python.sh -m pip install skyfield zfpy, numba, gdown
+RUN /isaac-sim/python.sh -m pip install skyfield zfpy numba gdown
 RUN /isaac-sim/python.sh -m pip install gdal==$(gdal-config --version)
 
 # isaac ros2_bridge config


### PR DESCRIPTION
A selector of the Dockefile was added based on the ability to pull from `nvcr.io`; otherwise, it mostly follows the original setup. However, mounting volumes is tricky due to the non-root `spaceros-user` inside the base image, so there is currently an ugly permission setting inside `run.sh`.