### PR TITLE
Update get_dems.sh

### DIFF
--- a/scripts/get_dems.sh
+++ b/scripts/get_dems.sh
@@ -12,7 +12,7 @@ CWD=$(pwd)
 mkdir -p tmp
 cd tmp
 
-cat $CWD/scripts/dems_list.txt | xargs -n 1 -P 8 wget -q -nc
+cat $CWD/scripts/dems_list.txt | xargs -n 1 -P 8 wget -nv -nc
 
 cd $CWD
 


### PR DESCRIPTION
the -q flag on wget in get-dems.sh makes it seem like the install script is hanging at this step if you have not great connection speeds to the US servers. --show-progress is way too buggy and verbose with the parallel downloads, but -nv just prints a new line every time a .tif file has completed downloading, showing the user that it's still working.