### PR TITLE
IsaacSim 4.1.0 python packages compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To simplify the remainder of the installation process of the framework we provid
 scripts/install_native.sh
 ```
 
-If you'd rather do it yourself, here are the commands:
+If you'd rather do it yourself, here are the commands for IsaacSim 2023.1.1:
 ```bash
 # Pulls WorldBuilder
 git submodule init
@@ -89,7 +89,7 @@ sudo apt-get install libgdal-dev
 version=$(gdal-config --version)
 
 # Install Python packages for Isaac Sim
-~/.local/share/ov/pkg/isaac_sim-2023.1.1/python.sh -m pip install opencv-python omegaconf hydra-core skyfield gdal==$version zfpy numba
+~/.local/share/ov/pkg/isaac-sim-2023.1.1/python.sh -m pip install opencv-python omegaconf hydra-core skyfield gdal==$version zfpy numba empy
 python3 -m pip install --upgrade pip
 python3 -m pip instal gdal==$version gdown black
 
@@ -107,6 +107,21 @@ rm lunar_rocks.zip
 # Get Ephemeris data
 ./scripts/get_ephemeris_data.sh
 ```
+
+For Isaac Sim 4.1.0, the python environment pre-installed numpy is incompatible with OmniLRS so it needs to be downgraded to 1.22.0. You also need to install lark package:
+
+```bash
+# Similar process with IsaacSim 2023.1.1 until Python packages installation
+
+# Install Python packages for Isaac Sim
+~/.local/share/ov/pkg/isaac-sim-4.1.0/python.sh -m pip install opencv-python omegaconf hydra-core skyfield gdal==$version zfpy numba empy lark
+~/.local/share/ov/pkg/isaac-sim-4.1.0/python.sh -m pip install --upgrade numpy==1.22.0
+python3 -m pip install --upgrade pip
+python3 -m pip instal gdal==$version gdown black
+
+# Continue with asset downloads
+```
+
 
 Once this is done you should be off to the races!
 However, before you venture forward, check that the assets folder has been created with success.

--- a/scripts/install_native.sh
+++ b/scripts/install_native.sh
@@ -16,11 +16,16 @@ echo "Installing Python packages for Isaac Sim"
 if [[ -e  ~/.local/share/ov/pkg/isaac_sim-2023.1.1/python.sh]]
 then
     ~/.local/share/ov/pkg/isaac_sim-2023.1.1/python.sh -m pip install opencv-python omegaconf hydra-core skyfield gdal==$version
-    ~/.local/share/ov/pkg/isaac_sim-2023.1.1/python.sh -m pip install zfpy numba
+    ~/.local/share/ov/pkg/isaac_sim-2023.1.1/python.sh -m pip install zfpy numba empy
 elif [[ -e ~/.local/share/ov/pkg/isaac-sim-2023.1.1/python.sh]]
 then
     ~/.local/share/ov/pkg/isaac-sim-2023.1.1/python.sh -m pip install opencv-python omegaconf hydra-core skyfield gdal==$version
-    ~/.local/share/ov/pkg/isaac-sim-2023.1.1/python.sh -m pip install zfpy numba
+    ~/.local/share/ov/pkg/isaac-sim-2023.1.1/python.sh -m pip install zfpy numba empy
+elif [[ -e ~/.local/share/ov/pkg/isaac-sim-4.1.0/python.sh]]
+then
+    ~/.local/share/ov/pkg/isaac-sim-4.1.0/python.sh -m pip install opencv-python omegaconf hydra-core skyfield gdal==$version
+    ~/.local/share/ov/pkg/isaac-sim-4.1.0/python.sh -m pip install zfpy numba empy lark
+    ~/.local/share/ov/pkg/isaac-sim-4.1.0/python.sh -m pip install --upgrade numpy==1.22.0
 else
     echo "Could not find Isaac Sim installation"
 fi


### PR DESCRIPTION
This PR add "empy" in IsaacSim 2023.1.1 and "lark" in IsaacSim 4.1.0 python env to suppress warning about not being able to find them. The PR also downgrade "numpy" preinstalled with IsaacSim 4.1.0 to version 1.22.0 to fix compatibility with numpy used by OmniLRS. Changes are made in documentaion README as well as the installation script for native installation.