### PR TITLE
fixed broken ros1 wrappers for the largescale environment

### DIFF
--- a/src/environments_wrappers/ros1/largescale_ros1.py
+++ b/src/environments_wrappers/ros1/largescale_ros1.py
@@ -53,7 +53,7 @@ class ROS_LargeScaleManager(ROS_BaseManager):
             rospy.Subscriber("/OmniLRS/Sun/AngularSize", Float32, self.set_sun_angle, queue_size=1)
         )
 
-    def periodicUpdate(self, dt: float) -> None:
+    def periodic_update(self, dt: float) -> None:
         """
         Updates the lab.
 


### PR DESCRIPTION
Hey Antoine,

I needed ROS1 for some custom nodes and I noticed that it wouldn't launch the large_scale environment because it didn't have some checks that were implemented in the ROS2 wrappers and also a typo that was making it revert to the base wrapper which returned a NotImplementedError.

Largescale working in Ros1 again (with removing Humble sourcing from the entrypoint and manually sourcing the Isaac included noetic setup.bash)

Thanks!