### PR TITLE
Terrain Deformation Fixes

### DIFF
--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -457,7 +457,7 @@ class RobotRigidGroup:
         n_links = len(self.target_links)
         contact_forces = np.zeros((n_links, 3))
         for i, prim_view in enumerate(self.prim_views):
-            contact_force = prim_view.get_net_contact_forces().squeeze()
+            contact_force = prim_view.get_net_contact_forces(dt = 1/60).squeeze()
             contact_forces[i, :] = contact_force
         return contact_forces
 

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -7,6 +7,7 @@ __email__ = "antoine.richard@uni.lu"
 __status__ = "development"
 
 from typing import Dict, List, Tuple
+from scipy.spatial.transform import Rotation as R
 import numpy as np
 import warnings
 import os
@@ -424,8 +425,16 @@ class RobotRigidGroup:
         orientations = np.zeros((n_links, 4))
         for i, prim in enumerate(self.prims):
             position, orientation = prim.get_world_pose()
+            quaternion = [orientation[1], orientation[2], orientation[3], orientation[0]]
+            rotation = R.from_quat(quaternion)
+            pitch_angle = 2 * np.arctan2(rotation.as_quat()[1], rotation.as_quat()[3])
+            pitch_correction_quat = [0, -np.sin(pitch_angle / 2), 0, np.cos(pitch_angle / 2)]
+            inverse_pitch_rotation = R.from_quat(pitch_correction_quat)
+            rotation_corrected = rotation * inverse_pitch_rotation
+            quaternion_corrected = rotation_corrected.as_quat()
+            orientation_corrected = [quaternion_corrected[3], quaternion_corrected[0], quaternion_corrected[1], quaternion_corrected[2]]
             positions[i, :] = position
-            orientations[i, :] = orientation
+            orientations[i, :] = orientation_corrected
         return positions, orientations
 
     def get_velocities(self) -> Tuple[np.ndarray, np.ndarray]:

--- a/src/terrain_management/deformation_engine.py
+++ b/src/terrain_management/deformation_engine.py
@@ -648,8 +648,8 @@ class DeformationEngine:
         n is the number of links.
         num_points = n * num_point_sample
         """
-        self.headings[:, 0] = 2.0 * (world_orientations[:, 0] * world_orientations[:, 3])
-        self.headings[:, 1] = 1.0 - 2.0 * (world_orientations[:, 3] * world_orientations[:, 3])
+        self.headings[:, 0] = 2.0 * (world_orientations[:, 0] * world_orientations[:, 3] + world_orientations[:, 1] * world_orientations[:, 2])
+        self.headings[:, 1] = 1.0 - 2.0 * (world_orientations[:, 2] * world_orientations[:, 2] + world_orientations[:, 3] * world_orientations[:, 3])
         projection_points = np.zeros((world_positions.shape[0], self.profile.shape[0], 2))
         projection_points[:, :, 0] = (
             self.profile[:, 0] * self.headings[:, 1, None]

--- a/src/terrain_management/deformation_engine.py
+++ b/src/terrain_management/deformation_engine.py
@@ -689,7 +689,7 @@ class DeformationEngine:
         """
         depth = np.zeros((normal_forces.shape[0], self.profile.shape[0]))
         amplitude, mean_value = self.force_depth_regression_model(normal_forces)
-        depth = self.boundary_dist[None, :] * (amplitude[:, None] * self.depth_dist[None, :] - mean_value[:, None])
+        depth = self.boundary_dist[None, :] * (amplitude[:, None]/2.0 * self.depth_dist[None, :] - mean_value[:, None])
         self.depth = depth.reshape(-1)
 
     def deform(


### PR DESCRIPTION
Fixed issues related to contact forces, wheeltrace amplitude, and wheeltrace orientation.

Contact Forces: 
Added the dt parameter; without this parameter, the values were being treated as contact impulses instead of contact forces https://docs.omniverse.nvidia.com/py/isaacsim/source/extensions/omni.isaac.core/docs/index.html#rigid-prim:~:text=999.99994%20999.99994%20999.99994%5D-,get_net_contact_forces,-(indices%3A

Wheeltrace Amplitude: 
Corrected a discrepancy in the calculation method between the simulation and the published paper

Wheeltrace Orientation: 
The wheeltrace orientation was not correctly aligned to the actual wheel orientation while turning

I’ll send you more details via Slack.