### PR TITLE
Fix: enforce Space ROS based on ROS 2 humble

### DIFF
--- a/spaceros_demo.docker/Dockerfile
+++ b/spaceros_demo.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:latest
+FROM osrf/space-ros:humble-2024.10.0
 
 RUN mkdir -p "${HOME_DIR}/spaceros/demo/src"
 WORKDIR "${HOME_DIR}/spaceros/demo/src"
@@ -14,7 +14,7 @@ RUN source /ros_entrypoint.sh -- && \
     colcon build --merge-install --symlink-install \
     --build-base "${DEMO_SPACEROS_WS_PATH}/build" \
     --install-base "${DEMO_SPACEROS_WS_PATH}/install" && \
-    rm -rf ./log 
+    rm -rf ./log
 
 WORKDIR "${HOME_DIR}"
 


### PR DESCRIPTION
The `osrf/space-ros:latest` docker image now installs Space ROS based on ROS 2 jazzy, which is not compatible with the current OmniLRS implementation. This quick fix enforces the installation of the most recent Space ROS image based on ROS 2 humble.