### PR TITLE
Quality: Update Hydra decorator to specify version_base parameter

### DIFF
--- a/run.py
+++ b/run.py
@@ -73,7 +73,7 @@ def instantiateConfigs(cfg: dict) -> dict:
     return ret
 
 
-@hydra.main(config_name="config", config_path="cfg")
+@hydra.main(config_name="config", config_path="cfg", version_base="1.2")
 def run(cfg: DictConfig):
     cfg = omegaconfToDict(cfg)
     cfg = instantiateConfigs(cfg)


### PR DESCRIPTION
## Description

The main entry point is missing the version_base parameter in the @hydra.main decorator, causing a deprecation warning. This needs to be updated to specify version_base="1.2" to use Hydra 1.2 defaults and eliminate the warning.

## Changes

- `run.py` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`


Closes #64