### PR TITLE
Change base_link to be of SingleXFormPrim type and specify base_link on deformable scenes

### DIFF
--- a/cfg/environment/lunalab_deformable.yaml
+++ b/cfg/environment/lunalab_deformable.yaml
@@ -162,3 +162,4 @@ robots_settings:
       orientation: [1, 0, 0, 0]
     domain_id: 0
     target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]
+    base_link: "base_link"

--- a/cfg/environment/lunaryard_20m_deformable.yaml
+++ b/cfg/environment/lunaryard_20m_deformable.yaml
@@ -329,3 +329,4 @@ robots_settings:
       orientation: [1, 0, 0, 0]
     domain_id: 0
     target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]
+    base_link: "base_link"

--- a/cfg/environment/lunaryard_40m_deformable.yaml
+++ b/cfg/environment/lunaryard_40m_deformable.yaml
@@ -195,3 +195,4 @@ robots_settings:
       orientation: [1, 0, 0, 0]
     domain_id: 0
     target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]
+    base_link: "base_link"

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -20,7 +20,7 @@ from isaacsim.core.api.world import World
 import omni.graph.core as og
 from isaacsim.core.utils.rotations import quat_to_rot_matrix
 from omni.isaac.dynamic_control import _dynamic_control
-from isaacsim.core.prims import SingleRigidPrim, RigidPrim
+from isaacsim.core.prims import SingleRigidPrim, SingleXFormPrim, RigidPrim
 from pxr import Gf, Usd
 
 from WorldBuilders.pxr_utils import createXform, createObject
@@ -570,8 +570,20 @@ class RobotRigidGroup:
                 self.prim_views.append(rigid_prim_view)
 
     def _initialize_base_link(self):
-        rigid_prim, rigid_prim_view = self._initialize_link(self.base_link)
-        self.base_prim = rigid_prim
+        if not self.base_link:
+            raise ValueError(
+                f"Robot '{self.robot_name}' is missing required 'base_link' in its YAML configuration. "
+                "Please add e.g. base_link: \"base_link\" under the robot's parameters."
+            )
+        # Use SingleXFormPrim instead of SingleRigidPrim for the base link.
+        # SingleRigidPrim eagerly queries physics velocities in its constructor,
+        # which fails when the physics tensor simulation view has been invalidated
+        # by prior RigidPrim view creations. The base link only needs get_world_pose(),
+        # so a transform-only prim is sufficient and avoids the tensor dependency.
+        self.base_prim = SingleXFormPrim(
+            prim_path=os.path.join(self.root_path, self.robot_name, self.base_link),
+            name=f"{self.robot_name}/{self.base_link}",
+        )
         print("initialized base link")
 
     def _initialize_link(self, link):


### PR DESCRIPTION
In order to deal with error on initialization of deformable scenes when loading the robot.

Related issues: closes #111 