### PR TITLE
fix rock instancer spawning rocks above/below ground 

### DIFF
--- a/cfg/environment/largescale_200km.yaml
+++ b/cfg/environment/largescale_200km.yaml
@@ -9,14 +9,14 @@ large_scale_terrain:
   hr_dem_generate_craters: True
   starting_position: [-7636, 10060]
   lr_dem_name: "ldem_87s_5mpp"
-  hr_dem_num_blocks: 1
-  block_size: 10
+  hr_dem_num_blocks: 4
+  block_size: 50
   crater_gen_densities: [0.025, 0.05, 0.5]
   crater_gen_radius: [[1.5, 2.5], [0.75, 1.5], [0.25, 0.5]]
   rock_gen_cfgs:
     -
       rock_sampler_cfg: 
-        block_size: 10
+        block_size: 50
         seed: 42
         rock_dist_cfg:
           position_distribution:
@@ -39,7 +39,7 @@ large_scale_terrain:
       texture_path: "assets/Textures/seaside_rock_2k.mdl"
     -
       rock_sampler_cfg:
-        block_size: 10
+        block_size: 50
         seed: 42
         rock_dist_cfg:
           position_distribution:
@@ -56,7 +56,7 @@ large_scale_terrain:
       rock_assets_folder: "assets/USD_Assets/rocks/small_rocks"
       instancer_name: "small_rock_instancer"
       seed: 47
-      block_span: 1
+      block_span: 2
       add_colliders: True
       collider_mode: "none"
       texture_name: "seaside_rock_2k"
@@ -82,6 +82,10 @@ sun_settings:
   azimuth: 90.0
   elevation: 5.0
 
+# The environment config includes the default robot_settings (tested to work out of the box), 
+# but the best practice for development is to have a separate robot config file that overides it
+# and launch the sim with run.py environment=... robot=...
+# (do not commit edits to the robot_settings below)
 robots_settings:
   robots_root: "/Robots"
   parameters:
@@ -93,12 +97,3 @@ robots_settings:
     domain_id: 0
     target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]
     base_link: "base_link" # core link used to determine the position of the robot
-
-    # robot_name: jackal
-    # usd_path: assets/USD_Assets/robots/ros2_jackal_PhysX_vlp16_stereo.usd
-    # # usd_path: assets/USD_Assets/robots/ros2_jackal_PhysX_vlp16.usd
-    # pose:
-    #   position: [5.0, 5.0, 0.5]
-    #   orientation: [1, 0, 0, 0]
-    # domain_id: 0
-    # target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]

--- a/cfg/environment/largescale_200km.yaml
+++ b/cfg/environment/largescale_200km.yaml
@@ -1,0 +1,104 @@
+name: LargeScale
+seed: 42
+physics_dt: 0.01666 # 60 Hz
+rendering_dt: 0.0333 # 30 Hz
+enforce_realtime: true
+
+# Stage settings, only edit if you know what you are doing.
+large_scale_terrain:
+  hr_dem_generate_craters: True
+  starting_position: [-7636, 10060]
+  lr_dem_name: "ldem_87s_5mpp"
+  hr_dem_num_blocks: 1
+  block_size: 10
+  crater_gen_densities: [0.025, 0.05, 0.5]
+  crater_gen_radius: [[1.5, 2.5], [0.75, 1.5], [0.25, 0.5]]
+  rock_gen_cfgs:
+    -
+      rock_sampler_cfg: 
+        block_size: 10
+        seed: 42
+        rock_dist_cfg:
+          position_distribution:
+            name: "thomas_point_process"
+            parent_density: 0.04
+            child_density: 100
+            sigma: 3.0
+            seed: 42
+          scale_distribution:
+            name: "uniform"
+            min: 0.02
+            max: 0.05
+            seed: 43
+      rock_assets_folder: "assets/USD_Assets/rocks/small_rocks"
+      instancer_name: "very_small_rock_instancer"
+      seed: 46
+      block_span: 1
+      add_colliders: False
+      texture_name: "seaside_rock_2k"
+      texture_path: "assets/Textures/seaside_rock_2k.mdl"
+    -
+      rock_sampler_cfg:
+        block_size: 10
+        seed: 42
+        rock_dist_cfg:
+          position_distribution:
+            name: "thomas_point_process"
+            parent_density: 0.01
+            child_density: 25
+            sigma: 3.0
+            seed: 44
+          scale_distribution:
+            name: "uniform"
+            min: 0.05
+            max: 0.2
+            seed: 45
+      rock_assets_folder: "assets/USD_Assets/rocks/small_rocks"
+      instancer_name: "small_rock_instancer"
+      seed: 47
+      block_span: 1
+      add_colliders: True
+      collider_mode: "none"
+      texture_name: "seaside_rock_2k"
+      texture_path: "assets/Textures/seaside_rock_2k.mdl"
+
+# stellar_engine_settings:
+#   start_date:
+#     year: 2024
+#     month: 5
+#     day: 7memeas
+#     hour: 5
+#     minute: 1
+#   time_scale: 1.0
+#   update_interval: 600
+
+sun_settings:
+  intensity: 1750.0
+  angle: 0.53
+  diffuse_multiplier: 1.0
+  specular_multiplier: 1.0
+  color: [1.0, 1.0, 1.0]
+  temperature: 6500.0
+  azimuth: 90.0
+  elevation: 5.0
+
+robots_settings:
+  robots_root: "/Robots"
+  parameters:
+    robot_name: husky
+    usd_path: assets/USD_Assets/robots/ros2_husky_PhysX_vlp16.usd
+    pose:
+      position: [0.0, 0.0, 0.5]
+      orientation: [1, 0, 0, 0]
+    domain_id: 0
+    target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]
+    base_link: "base_link" # core link used to determine the position of the robot
+
+    # robot_name: jackal
+    # usd_path: assets/USD_Assets/robots/ros2_jackal_PhysX_vlp16_stereo.usd
+    # # usd_path: assets/USD_Assets/robots/ros2_jackal_PhysX_vlp16.usd
+    # pose:
+    #   position: [5.0, 5.0, 0.5]
+    #   orientation: [1, 0, 0, 0]
+    # domain_id: 0
+    # target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]

--- a/cfg/robot/husky.yaml
+++ b/cfg/robot/husky.yaml
@@ -1,0 +1,30 @@
+# @package environment 
+# do not remove the above comment, it injects the below configs into environment configs
+
+robots_settings:
+  parameters:
+    robot_name: husky
+    usd_path: assets/USD_Assets/robots/ros2_husky_PhysX_vlp16.usd
+    # usd_path: assets/USD_Assets/robots/ros2_husky_PhysX_vlp16_mono_depth_imu.usd
+    pose:
+        position: [26., 16.6, 0.8]
+        orientation: [0., 0., 0.70711, 0.70711]
+    base_link: "base_link" # core link used to determine the position of the robot
+    target_links: ["front_left_wheel_link", "front_right_wheel_link", "rear_left_wheel_link", "rear_right_wheel_link"]
+
+    # base_link: "base_link" # core link used to determine the position of the robot
+    # dimensions:
+    #   width: 1.6 # m
+    #   length: 1.5
+    # pos_relative_to_prim: "/StaticAssets/lander"
+    # wheel_joints:
+    #   left: ["wheel_fl", "wheel_ml", "wheel_bl"]
+    #   right: ["wheel_fr", "wheel_mr", "wheel_br"]
+    # camera:
+    #   prim_path: "/Robots/pragyaan/Body/body_main/depth_cam"
+    #   resolutions: 
+    #     low: [320, 240]
+    #     high: [1440, 1080]
+    # imu_sensor_path: "/Robots/pragyaan/base_link/Imu_Sensor"
+    # turn_speed_coef: 19
+    # solar_panel_joint: "solarJoint"  # finds it within the main robot articulation

--- a/cfg/robot/pragyaan.yaml
+++ b/cfg/robot/pragyaan.yaml
@@ -8,7 +8,6 @@ robots_settings:
     pose:
       position: [26., 16.6, 0.8]
       orientation: [0., 0., 0.70711, 0.70711]
-    domain_id: 0
     target_links: [
       "Mobility/Wheel_front_left",
       "Mobility/Wheel_front_right",

--- a/cfg/robot/pragyaan.yaml
+++ b/cfg/robot/pragyaan.yaml
@@ -8,6 +8,7 @@ robots_settings:
     pose:
       position: [26., 16.6, 0.8]
       orientation: [0., 0., 0.70711, 0.70711]
+    base_link: "base_link" # core link used to determine the position of the robot
     target_links: [
       "Mobility/Wheel_front_left",
       "Mobility/Wheel_front_right",

--- a/src/terrain_management/large_scale_terrain/rock_manager.py
+++ b/src/terrain_management/large_scale_terrain/rock_manager.py
@@ -11,6 +11,7 @@ import numpy as np
 import dataclasses
 import threading
 import logging
+import math
 import time
 import os
 
@@ -565,7 +566,12 @@ class RockGenerator:
     """
 
     def __init__(
-        self, settings: RockGeneratorConf, sampling_func: callable, is_map_done: callable, instancer_path: str
+        self,
+        settings: RockGeneratorConf,
+        sampling_func: callable,
+        is_map_done: callable,
+        instancer_path: str,
+        world_offset: Tuple[float, float] = (0.0, 0.0),
     ):
         """
         Args:
@@ -573,12 +579,17 @@ class RockGenerator:
             sampling_func (callable): The function to sample the rocks.
             is_map_done (callable): The function to check if the map is done.
             instancer_path (str): The path to the instancer.
+            world_offset (Tuple[float, float]): Offset subtracted from rock positions
+                before they are written to the USD instancer. Used when rocks are
+                sampled in a global frame but rendered in a local frame whose origin
+                is at ``world_offset``.
         """
 
         self.settings = settings
         self.sampling_func = sampling_func
         self.is_map_done = is_map_done
         self.instancer_path = instancer_path
+        self.world_offset = (float(world_offset[0]), float(world_offset[1]))
         self.is_sampling = False
 
     def build(self) -> None:
@@ -642,32 +653,31 @@ class RockGenerator:
         y_block = int(y // self.settings.block_size) * self.settings.block_size
         return (x_block, y_block)
 
-    def define_region(self, coordinates: Tuple[float, float]) -> BoundingBox:
+    def define_region(self, block_corner: Tuple[float, float]) -> BoundingBox:
         """
-        Defines the region to sample the rocks. The region is defined by the coordinates
-        and the block span. The block span is the number of blocks to sample around the
-        coordinates.
-
-        The region is defined by the following formula:
-            x_low = coordinates[0] - (block_span + 1) * block_size
-            x_high = coordinates[0] + (block_span + 2) * block_size
-            y_low = coordinates[1] - (block_span + 1) * block_size
-            y_high = coordinates[1] + (block_span + 2) * block_size
-
-        Note the +1 on the minimum and +2 on the maximum. This is done to have a buffer of
-        blocks around the sampling region.
+        Defines the region to sample the rocks. The region is anchored on the rover's
+        block corner (NOT the raw rover position) and spans ``block_span`` blocks on
+        the negative side and ``block_span + 1`` blocks on the positive side along
+        each axis. This is intentionally identical to the layout used by the HR DEM
+        block grid (see ``HighResDEMGen.build_block_grid``), so when ``block_span``
+        equals the HR DEM's ``num_blocks`` the rock region exactly matches the
+        populated area of the high-resolution DEM.
 
         Args:
-            coordinates (Tuple[float, float]): The coordinates to define the region around.
+            block_corner (Tuple[float, float]): the rover's block corner (in the same
+                frame in which rocks will be placed). MUST be a multiple of
+                ``block_size``.
 
         Returns:
-            BoundingBox: The bounding box of the region.
+            BoundingBox: the bounding box of the region.
         """
 
-        x_low = coordinates[0] - (self.settings.block_span) * self.settings.block_size
-        x_high = coordinates[0] + (self.settings.block_span + 1) * self.settings.block_size
-        y_low = coordinates[1] - (self.settings.block_span) * self.settings.block_size
-        y_high = coordinates[1] + (self.settings.block_span + 1) * self.settings.block_size
+        block_size = self.settings.block_size
+        block_span = self.settings.block_span
+        x_low = int(block_corner[0]) - block_span * block_size
+        x_high = int(block_corner[0]) + (block_span + 1) * block_size
+        y_low = int(block_corner[1]) - block_span * block_size
+        y_high = int(block_corner[1]) + (block_span + 1) * block_size
 
         return BoundingBox(x_min=x_low, x_max=x_high, y_min=y_low, y_max=y_high)
 
@@ -701,7 +711,8 @@ class RockGenerator:
         """
         Updates the instancer with the new block data. The function gets the blocks within
         the region and aggregates the block data. It then sets the instancer's parameters
-        with the new data.
+        with the new data. Rock positions are translated by ``-world_offset`` so that
+        rocks sampled in a global frame render correctly in the local world frame.
 
         Args:
             region (BoundingBox): The region to sample the rocks.
@@ -709,30 +720,87 @@ class RockGenerator:
 
         blocks, _, _ = self.rock_db.get_blocks_within_region(region)
         position, orientation, scale, ids = self.aggregate_block_data(blocks)
+        self.check_rocks_in_fine_mesh(position, region)
+        position = position.copy()
+        position[:, 0] -= self.world_offset[0]
+        position[:, 1] -= self.world_offset[1]
         self.rock_instancer.set_instancer_parameters(position, orientation, scale, ids)
 
-    def sample(self, global_position: Tuple[float, float]) -> None:
+    def check_rocks_in_fine_mesh(self, position: np.ndarray, region: BoundingBox) -> None:
         """
-        Samples the rocks at the given position. The function casts the position to the block
-        space and defines the region around the position. It then samples the rocks within the
-        region and updates the instancer with the new data.
+        Sanity check: report whether any sampled rock has the sentinel z == 0
+        elevation, which indicates the elevation kernel sampled outside the
+        populated high-resolution DEM (i.e. a floating rock).
+
+        Note:
+            Rocks are allowed to fall slightly outside the sampling region in xy
+            because the Thomas point process scatters children around parents with
+            ``sigma`` meters of spread; ``dissect_region_blocks`` then absorbs them
+            into the boundary blocks. So an xy-out-of-region count is informational
+            only, not an error.
 
         Args:
-            position (Tuple[float, float]): The position to sample the rocks.
-            map_coordinates (Tuple[float, float]): The coordinates in the map space.
+            position (np.ndarray): Rock world-frame positions (Nx3) before
+                ``world_offset`` is subtracted.
+            region (BoundingBox): The rock sampling region in the same frame.
+        """
+
+        prefix = f"[RockGenerator/{self.settings.instancer_name}]"
+
+        if position.shape[0] == 0:
+            print(f"{prefix} no rocks sampled")
+            return
+
+        x = position[:, 0]
+        y = position[:, 1]
+        z = position[:, 2]
+
+        out_x = (x < region.x_min) | (x >= region.x_max)
+        out_y = (y < region.y_min) | (y >= region.y_max)
+        outside_xy = int(np.count_nonzero(out_x | out_y))
+        zero_z = int(np.count_nonzero(z == 0.0))
+        total = int(position.shape[0])
+
+        print(
+            f"{prefix} sampled={total} "
+            f"region=x[{region.x_min},{region.x_max}) y[{region.y_min},{region.y_max}) "
+            f"xy_outside_region={outside_xy} (expected: scatter from Thomas process) "
+            f"z==0={zero_z}"
+        )
+        if zero_z > 0:
+            logger.warning(
+                "%s %d/%d rocks have z==0 (likely sampled outside the populated HR DEM); "
+                "ensure block_span <= hr_dem_num_blocks",
+                prefix,
+                zero_z,
+                total,
+            )
+
+    def sample(self, global_position: Tuple[float, float], dem_reference: Tuple[float, float]) -> None:
+        """
+        Samples the rocks at the given position. The function defines the region around the
+        rover position and samples the rocks within the region. The elevation lookup is
+        performed using ``dem_reference`` as the kernel reference frame.
+
+        Args:
+            global_position (Tuple[float, float]): The rover position used to center the
+                sampling region. Rocks will be placed in this frame.
+            dem_reference (Tuple[float, float]): The reference position passed to the
+                elevation kernel. Must equal the block-corner of the rover (in the same
+                frame as ``global_position``) so that ``(rock_pos - dem_reference)``
+                correctly maps to a pixel in the high-resolution DEM.
         """
 
         while not self.is_map_done():
             time.sleep(0.1)
 
         self.is_sampling = True
-        coordinates = self.cast_coordinates_to_block_space(global_position)
-        region = self.define_region(coordinates)
-        self.rock_sampler.sample_rocks_by_region(region, global_position)
+        region = self.define_region(dem_reference)
+        self.rock_sampler.sample_rocks_by_region(region, dem_reference)
         self.update_instancer(region)
         self.is_sampling = False
 
-    def _sample_threaded(self, position: Tuple[float, float]) -> None:
+    def _sample_threaded(self, position: Tuple[float, float], dem_reference: Tuple[float, float]) -> None:
         """
         Internal function DO NOT CALL.
 
@@ -741,23 +809,25 @@ class RockGenerator:
 
         Args:
             position (Tuple[float, float]): The position to sample the rocks.
+            dem_reference (Tuple[float, float]): The reference position for the elevation kernel.
         """
 
         while self.is_sampling:
             time.sleep(0.1)
 
-        self.sample(position)
+        self.sample(position, dem_reference)
 
-    def sample_threaded(self, position: Tuple[float, float]) -> None:
+    def sample_threaded(self, position: Tuple[float, float], dem_reference: Tuple[float, float]) -> None:
         """
         Samples the rocks at the given position in a separate thread. The function waits for potential
         previous calls to finish before starting a new one.
 
         Args:
             position (Tuple[float, float]): The position to sample the rocks.
+            dem_reference (Tuple[float, float]): The reference position for the elevation kernel.
         """
 
-        thread = threading.Thread(target=self._sample_threaded, args=(position,))
+        thread = threading.Thread(target=self._sample_threaded, args=(position, dem_reference))
         thread.start()
 
 
@@ -790,17 +860,27 @@ class RockManager:
     rock generators and samples the rocks around a given position.
     """
 
-    def __init__(self, settings: RockManagerConf, sampling_func: callable, is_map_done: callable) -> None:
+    def __init__(
+        self,
+        settings: RockManagerConf,
+        sampling_func: callable,
+        is_map_done: callable,
+        world_offset: Tuple[float, float] = (0.0, 0.0),
+    ) -> None:
         """
         Args:
             settings (RockManagerConf): The settings for the rock manager.
             sampling_func (callable): The function to sample the rocks height and normals.
             is_map_done (callable): The function to check if the map is done.
+            world_offset (Tuple[float, float]): Offset subtracted from rock positions
+                before they are rendered. Use this when rock sampling is done in a
+                global frame whose origin differs from the rendered world's origin.
         """
 
         self.settings = settings
         self.sampling_func = sampling_func
         self.is_map_done = is_map_done
+        self.world_offset = (float(world_offset[0]), float(world_offset[1]))
         self.last_update = None
 
     def build(self) -> None:
@@ -814,7 +894,11 @@ class RockManager:
             if rock_gen_cfg.seed is None:
                 rock_gen_cfg.seed = self.settings.seed + i * 4
             rock_generator = RockGenerator(
-                rock_gen_cfg, self.sampling_func, self.is_map_done, self.settings.instancers_path
+                rock_gen_cfg,
+                self.sampling_func,
+                self.is_map_done,
+                self.settings.instancers_path,
+                world_offset=self.world_offset,
             )
             rock_generator.build()
             self.rock_generators.append(rock_generator)
@@ -855,14 +939,17 @@ class RockManager:
             x_last, y_last = self.last_update
             return (x != x_last) or (y != y_last)
 
-    def sample(self, global_position: Tuple[float, float]) -> None:
+    def sample(self, global_position: Tuple[float, float], dem_reference: Tuple[float, float]) -> None:
         """
         Samples the rocks at the given position. The function samples the rocks for each rock
         generator.
 
         Args:
-            global_position (Tuple[float, float]): The position to sample the rocks.
-            map_coordinates (Tuple[float, float]): The coordinates in the map space.
+            global_position (Tuple[float, float]): The rover position used to center the rock
+                sampling region. Rocks will be placed in this frame.
+            dem_reference (Tuple[float, float]): The reference position passed to the elevation
+                kernel. Must be the block-corner of the rover (in the same frame as
+                ``global_position``) so that elevation lookups land at the correct DEM pixel.
         """
         position = self.cast_coordinates_to_block_space(global_position)
 
@@ -870,18 +957,20 @@ class RockManager:
             self.last_update = position
             for rock_generator in self.rock_generators:
                 with ScopedTimer("RockManager sample", active=self.settings.profiling):
-                    rock_generator.sample(position)
+                    rock_generator.sample(global_position, dem_reference)
 
-    def sample_threaded(self, global_position: Tuple[float, float]) -> None:
+    def sample_threaded(self, global_position: Tuple[float, float], dem_reference: Tuple[float, float]) -> None:
         """
         Samples the rocks at the given position in a separate thread. The function samples the rocks
         for each rock generator in a separate thread.
 
         Args:
-            global_position (Tuple[float, float]): The position to sample the rocks.
+            global_position (Tuple[float, float]): The rover position used to center the rock
+                sampling region.
+            dem_reference (Tuple[float, float]): The reference position for the elevation kernel.
         """
 
         position = self.cast_coordinates_to_block_space(global_position)
         if self.check_if_update_needed(position):
             for rock_generator in self.rock_generators:
-                rock_generator.sample_threaded(position)
+                rock_generator.sample_threaded(global_position, dem_reference)

--- a/src/terrain_management/large_scale_terrain/rock_manager.py
+++ b/src/terrain_management/large_scale_terrain/rock_manager.py
@@ -778,13 +778,16 @@ class RockGenerator:
 
     def sample(self, global_position: Tuple[float, float], dem_reference: Tuple[float, float]) -> None:
         """
-        Samples the rocks at the given position. The function defines the region around the
-        rover position and samples the rocks within the region. The elevation lookup is
-        performed using ``dem_reference`` as the kernel reference frame.
+        Samples the rocks. The sampling region is centered on ``dem_reference`` (the
+        rover's block corner), NOT on the raw ``global_position``; see ``define_region``.
+        The elevation lookup is performed using ``dem_reference`` as the kernel
+        reference frame.
 
         Args:
-            global_position (Tuple[float, float]): The rover position used to center the
-                sampling region. Rocks will be placed in this frame.
+            global_position (Tuple[float, float]): The rover position, in the frame in
+                which rocks will be placed. Currently unused inside this function (the
+                region is anchored on ``dem_reference``); kept for API symmetry with
+                ``RockManager.sample`` and potential future use.
             dem_reference (Tuple[float, float]): The reference position passed to the
                 elevation kernel. Must equal the block-corner of the rover (in the same
                 frame as ``global_position``) so that ``(rock_pos - dem_reference)``
@@ -808,8 +811,11 @@ class RockGenerator:
         calls to finish before starting a new one.
 
         Args:
-            position (Tuple[float, float]): The position to sample the rocks.
-            dem_reference (Tuple[float, float]): The reference position for the elevation kernel.
+            position (Tuple[float, float]): The rover position, in the frame in which
+                rocks will be placed.
+            dem_reference (Tuple[float, float]): The reference position passed to the
+                elevation kernel. Must equal the block-corner of ``position`` (in the
+                same frame) so elevation lookups land at the correct DEM pixel.
         """
 
         while self.is_sampling:
@@ -823,8 +829,11 @@ class RockGenerator:
         previous calls to finish before starting a new one.
 
         Args:
-            position (Tuple[float, float]): The position to sample the rocks.
-            dem_reference (Tuple[float, float]): The reference position for the elevation kernel.
+            position (Tuple[float, float]): The rover position, in the frame in which
+                rocks will be placed.
+            dem_reference (Tuple[float, float]): The reference position passed to the
+                elevation kernel. Must equal the block-corner of ``position`` (in the
+                same frame) so elevation lookups land at the correct DEM pixel.
         """
 
         thread = threading.Thread(target=self._sample_threaded, args=(position, dem_reference))
@@ -965,9 +974,11 @@ class RockManager:
         for each rock generator in a separate thread.
 
         Args:
-            global_position (Tuple[float, float]): The rover position used to center the rock
-                sampling region.
-            dem_reference (Tuple[float, float]): The reference position for the elevation kernel.
+            global_position (Tuple[float, float]): The rover position, in the frame in
+                which rocks will be placed.
+            dem_reference (Tuple[float, float]): The reference position passed to the
+                elevation kernel. Must equal the block-corner of ``global_position``
+                (in the same frame) so elevation lookups land at the correct DEM pixel.
         """
 
         position = self.cast_coordinates_to_block_space(global_position)

--- a/src/terrain_management/large_scale_terrain_manager.py
+++ b/src/terrain_management/large_scale_terrain_manager.py
@@ -95,6 +95,7 @@ class LargeScaleTerrainManager:
             self.rock_manager_cfg,
             self.nested_clipmap_manager.get_height_and_random_scale,
             is_map_done,
+            world_offset=self.settings.starting_position,
         )
         self.rock_manager.build()
 
@@ -231,7 +232,16 @@ class LargeScaleTerrainManager:
 
             self.nested_clipmap_manager.update_clipmaps(fine_position, coarse_position, corrected_coordinates)
             print("clipmaps updated")
-            self.rock_manager.sample(local_coordinates)
+            # The rock DB requires block-aligned coordinates (multiples of block_size).
+            # Local frame is offset by `starting_position` which is generally NOT block
+            # aligned, so we sample rocks in the GLOBAL frame and let the rock manager
+            # subtract the world offset when feeding positions to the instancer.
+            bs = self.settings.block_size
+            block_corner_global = (
+                int(global_corrected_coordinates[0] // bs) * bs,
+                int(global_corrected_coordinates[1] // bs) * bs,
+            )
+            self.rock_manager.sample(global_corrected_coordinates, block_corner_global)
             print("rock manager sampled")
             self.collider_manager.update_shifting_map(local_coordinates)
             print("collider manager updated")


### PR DESCRIPTION
flying rocks due to being spawned outside fine mesh or rock coordinates not matching local/global frames on some combination of 

`block_size (m)` side length of one HR-DEM tile. The fundamental grid unit shared by the HR DEM, the rock DB, and the colliders.

`hr_dem_num_blocks (count)` how many tiles around the rover are populated (with crater + interpolation work) on each side. Populated fine-mesh area = (2·hr_dem_num_blocks + 1) · block_size per side.

`block_span (per rock generator, count)` how many tiles around the rover the rock sampler covers on each side. Rock region = (2·block_span + 1) · block_size per side. Must satisfy block_span ≤ hr_dem_num_blocks, otherwise rocks land outside the populated DEM and float at z=0.