### PR TITLE
added guard to check yamcs server is up before launching simulation

### DIFF
--- a/src/environments_wrappers/yamcs/simulation_manager_yamcs.py
+++ b/src/environments_wrappers/yamcs/simulation_manager_yamcs.py
@@ -10,7 +10,9 @@ from isaacsim import SimulationApp
 from isaacsim.core.api.world import World
 from typing import Union
 import logging
+import time
 import omni
+from yamcs.client import YamcsClient
 
 from src.configurations.simulator_mode_enum import SimulatorMode
 from src.environments.large_scale_lunar import LargeScaleController
@@ -58,6 +60,13 @@ class Yamcs_SimulationManager:
         self.cfg = cfg
         self.simulation_app = simulation_app
         self.timeline = omni.timeline.get_timeline_interface()
+
+        # Block here until the Yamcs server is reachable. This avoids the
+        # ConnectionFailure crash users hit when launching the sim before the
+        # Yamcs server is up. We do this before creating the World/scene so no
+        # simulation state can drift while we wait.
+        self._wait_for_yamcs(cfg["mode"]["instance_conf"]["address"])
+
         self.world = World(
             stage_units_in_meters=1.0,
             physics_dt=cfg["environment"]["physics_dt"],
@@ -83,6 +92,43 @@ class Yamcs_SimulationManager:
         self._start_TMTC()
         self.EC.add_robot_manager(self.RM)
         self._step_world_and_reset()
+
+    def _wait_for_yamcs(self, address: str, poll_interval: float = 1.0) -> None:
+        """
+        Block until the Yamcs server at ``address`` responds, polling every
+        ``poll_interval`` seconds. Pumps ``simulation_app.update()`` between
+        polls so the Isaac Sim window stays responsive while waiting.
+        """
+        # Silence urllib3's per-connection DEBUG spam during polling. The
+        # main YamcsTMTC module also sets this, but it hasn't been imported yet.
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+        probe_client = YamcsClient(address)
+        attempt = 0
+        announced_waiting = False
+        while True:
+            try:
+                probe_client.get_server_info()
+                print(f"[Yamcs] Server at {address} is reachable. Continuing startup.", flush=True)
+                return
+            except Exception as e:
+                if not announced_waiting:
+                    print(
+                        f"[Yamcs] Server at {address} is not reachable yet ({e.__class__.__name__}). "
+                        f"Waiting... Press Ctrl-C to abort.",
+                        flush=True,
+                    )
+                    announced_waiting = True
+                elif attempt % 10 == 0:
+                    # Re-announce every ~10 polls so the user knows we're still waiting.
+                    print(f"[Yamcs] Still waiting for server at {address}...", flush=True)
+            attempt += 1
+            # Keep the Isaac Sim window responsive while we wait.
+            try:
+                self.simulation_app.update()
+            except Exception:
+                pass
+            time.sleep(poll_interval)
 
     def _start_TMTC(self):
         robot_name = self.RM.robot.robot_name.replace("/","") 


### PR DESCRIPTION
polling of yamcs server every 1s
resumes sim startup once connected

<img width="915" height="247" alt="image" src="https://github.com/user-attachments/assets/7ef4db8a-7ecb-4f29-98d1-01f45974579b" />
