### PR TITLE
Refactor: replace Dynamic Control with ArticulationControl telemetry API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ assets/Terrains/SouthPole/
 # Test venv and outputs
 test/venv/
 test/outputs/
+
+Session.vim

--- a/src/environments_wrappers/ros2/robot_manager_ros2.py
+++ b/src/environments_wrappers/ros2/robot_manager_ros2.py
@@ -1,4 +1,4 @@
-__author__ = "Antoine Richard, Aleksa Stanivuk"
+__author__ = "Antoine Richard, Aleksa Stanivuk, Shamistan Karimov"
 __copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
 __license__ = "BSD-3-Clause"
 __version__ = "1.0.0"
@@ -87,18 +87,16 @@ class ROS_RobotManager(Node):
 
         p = [data.pose.position.x, data.pose.position.y, data.pose.position.z]
         q = [data.pose.orientation.x, data.pose.orientation.y, data.pose.orientation.z, data.pose.orientation.w]
-        print(f"received {data.pose.position}")
+        # print(f"received {data.pose.position}")
         self.modifications.append([self.RM.teleport_robot, {"position": p, "orientation": q}])
 
-    def reset_robot(self) -> None:
+    def reset_robot(self, msg=None) -> None:
         """
         Resets a robot.
-
-        Args:
-            data (String): Name of the robot to reset.
         """
 
-        self.modifications.append([self.RM.reset_robot])
+        self.modifications.append([self.RM.reset_robot, {}])
+
 
     def cleanRobots(self) -> None:
         """

--- a/src/environments_wrappers/ros2/robot_manager_ros2.py
+++ b/src/environments_wrappers/ros2/robot_manager_ros2.py
@@ -87,6 +87,7 @@ class ROS_RobotManager(Node):
 
         p = [data.pose.position.x, data.pose.position.y, data.pose.position.z]
         q = [data.pose.orientation.x, data.pose.orientation.y, data.pose.orientation.z, data.pose.orientation.w]
+        print(f"received {data.pose.position}")
         self.modifications.append([self.RM.teleport_robot, {"position": p, "orientation": q}])
 
     def reset_robot(self) -> None:

--- a/src/environments_wrappers/ros2/simulation_manager_ros2.py
+++ b/src/environments_wrappers/ros2/simulation_manager_ros2.py
@@ -6,28 +6,29 @@ __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 __status__ = "development"
 
+import logging
 from threading import Thread
+from typing import Union
 
+import omni
+import rclpy
 from isaacsim import SimulationApp
 from isaacsim.core.api.world import World
-from typing import Union
-import logging
-import omni
+from rclpy.executors import SingleThreadedExecutor as Executor
 
+from src.configurations.procedural_terrain_confs import TerrainManagerConf
 from src.environments.stellar_engine_env_mixin import StellarEngineEnvMixin
 from src.environments.utils import set_moon_env_name
 from src.environments_wrappers.rate import Rate
 from src.environments_wrappers.ros2.largescale_ros2 import ROS_LargeScaleManager
+from src.environments_wrappers.ros2.lunalab_ros2 import ROS_LunalabManager
 from src.environments_wrappers.ros2.lunaryard_ros2 import ROS_LunaryardManager
 from src.environments_wrappers.ros2.robot_manager_ros2 import ROS_RobotManager
-from src.environments_wrappers.ros2.lunalab_ros2 import ROS_LunalabManager
-from src.configurations.procedural_terrain_confs import TerrainManagerConf
-from rclpy.executors import SingleThreadedExecutor as Executor
 from src.physics.physics_scene import PhysicsSceneManager
-import rclpy
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p")
+
 
 class ROS2_EnvironmentManagerFactory:
     def __init__(self):
@@ -156,11 +157,16 @@ class ROS2_SimulationManager:
         else:
             self.ROSRobotManager.RM.preload_robot(self.world)
         self.ROSEnvironmentManager.EC.add_robot_manager(self.ROSRobotManager.RM)
-        if isinstance(self.ROSEnvironmentManager.EC, StellarEngineEnvMixin) and self.ROSRobotManager.RM.robot.subsystems is not None:
+        if (
+            isinstance(self.ROSEnvironmentManager.EC, StellarEngineEnvMixin)
+            and self.ROSRobotManager.RM.robot.subsystems is not None
+        ):
             # True for Lunaryard and LargeScale, False for Lunalab
             # subsystems uses sun directions to calculate views no matter if stellar engine is enabled (sun moves) or not
             # subsystems is only initialized for mission-specific robots (e.g. pragyaan); skip otherwise.
-            self.ROSRobotManager.RM.robot.subsystems.set_sun_prim_path(self.ROSEnvironmentManager.EC.get_sun_prim_path())
+            self.ROSRobotManager.RM.robot.subsystems.set_sun_prim_path(
+                self.ROSEnvironmentManager.EC.get_sun_prim_path()
+            )
 
         for i in range(100):
             self.world.step(render=True)
@@ -176,22 +182,42 @@ class ROS2_SimulationManager:
             self.rate.reset()
             self.world.step(render=True)
             if self.world.is_playing():
-                # Apply modifications to the lab only once the simulation step is finished
-                # This is extremely important as modifying the stage during a simulation step
-                # will lead to a crash.
-                self.ROSEnvironmentManager.periodic_update(dt=self.world.get_physics_dt())
+                did_reset = False
+
                 if self.world.current_time_step_index == 0:
                     self.world.reset()
+                    did_reset = True
+
+                    if self.ROSRobotManager.RM.robot is not None:
+                        self.ROSRobotManager.RM.robot.invalidate_articulation_api()
+
                     self.ROSEnvironmentManager.reset()
                     self.ROSRobotManager.reset()
-                self.ROSEnvironmentManager.apply_modifications()
-                if self.ROSEnvironmentManager.trigger_reset:
-                    self.ROSRobotManager.reset()
-                    self.ROSEnvironmentManager.trigger_reset = False
-                self.ROSRobotManager.apply_modifications()
-                if self.enable_deformation:
-                    if self.world.current_time_step_index >= (self.deform_delay * self.world.get_physics_dt()):
-                        self.ROSEnvironmentManager.EC.deform_terrain()
+
+                if not did_reset:
+                    # Must happen before periodic_update(), because LargeScale may call robot.get_pose().
+                    if self.ROSRobotManager.RM.robot is not None:
+                        self.ROSRobotManager.RM.robot.update_articulation_api()
+
+                    # Apply modifications to the lab only once the simulation step is finished.
+                    # This is extremely important as modifying the stage during a simulation step
+                    # will lead to a crash.
+                    self.ROSEnvironmentManager.periodic_update(dt=self.world.get_physics_dt())
+
+                    self.ROSEnvironmentManager.apply_modifications()
+
+                    if self.ROSEnvironmentManager.trigger_reset:
+                        self.ROSRobotManager.reset()
+                        self.ROSEnvironmentManager.trigger_reset = False
+
+                        if self.ROSRobotManager.RM.robot is not None:
+                            self.ROSRobotManager.RM.robot.invalidate_articulation_api()
+
+                    self.ROSRobotManager.apply_modifications()
+
+                    if self.enable_deformation:
+                        if self.world.current_time_step_index >= (self.deform_delay * self.world.get_physics_dt()):
+                            self.ROSEnvironmentManager.EC.deform_terrain()
                         # self.ROSLabManager.EC.applyTerramechanics()
             if not self.ROSEnvironmentManager.monitor_thread_is_alive():
                 logger.debug("Destroying the ROS nodes")

--- a/src/environments_wrappers/ros2/simulation_manager_ros2.py
+++ b/src/environments_wrappers/ros2/simulation_manager_ros2.py
@@ -1,4 +1,4 @@
-__author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk"
+__author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk, Shamistan Karimov"
 __copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
 __license__ = "BSD-3-Clause"
 __version__ = "2.0.0"

--- a/src/environments_wrappers/yamcs/simulation_manager_yamcs.py
+++ b/src/environments_wrappers/yamcs/simulation_manager_yamcs.py
@@ -1,38 +1,40 @@
-__author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2026, JAOPS"
+__author__ = "Aleksa Stanivuk, Shamistan Karimov, Bach Nguyen"
+__copyright__ = "Copyright 2026, JAOPS, AsteriaART/Artefacts"
 __license__ = "BSD-3-Clause"
 __version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 __status__ = "development"
 
-from isaacsim import SimulationApp
-from isaacsim.core.api.world import World
-from typing import Union
 import logging
 import time
+from typing import Union
+
 import omni
+from isaacsim import SimulationApp
+from isaacsim.core.api.world import World
 from yamcs.client import YamcsClient
 
+from src.configurations.procedural_terrain_confs import TerrainManagerConf
 from src.configurations.simulator_mode_enum import SimulatorMode
 from src.environments.large_scale_lunar import LargeScaleController
 from src.environments.lunalab import LunalabController
 from src.environments.lunaryard import LunaryardController
 from src.environments.stellar_engine_env_mixin import StellarEngineEnvMixin
 from src.environments.utils import set_moon_env_name
-from src.configurations.procedural_terrain_confs import TerrainManagerConf
 from src.environments_wrappers.rate import Rate
 from src.robots.robot import RobotManager
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(format="%(asctime)s %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p")
 
+
 class Yamcs_SimulationManager:
     """
     Manages the simulation. This class is responsible for:
     - Initializing the simulation
-    - Running the environment manager 
-    - Running the robot manager 
+    - Running the environment manager
+    - Running the robot manager
     - Running the simulation
     - Cleaning the simulation
 
@@ -80,9 +82,8 @@ class Yamcs_SimulationManager:
         self.EC = self._get_environment_controller(self.cfg["environment"]["name"])
         self.EC.load()
 
-        self.RM = RobotManager(cfg["environment"]["robots_settings"], 
-                               mode=SimulatorMode.YAMCS)
-        
+        self.RM = RobotManager(cfg["environment"]["robots_settings"], mode=SimulatorMode.YAMCS)
+
         self._setup_terrain_manager()
         self._preload_robot()
         if isinstance(self.EC, StellarEngineEnvMixin) and self.RM.robot.subsystems is not None:
@@ -132,39 +133,49 @@ class Yamcs_SimulationManager:
             time.sleep(poll_interval)
 
     def _start_TMTC(self):
-        robot_name = self.RM.robot.robot_name.replace("/","") 
+        robot_name = self.RM.robot.robot_name.replace("/", "")
         controller_name = self.RM.RM_conf.robot_controller
 
         if controller_name == "pragyaan-controller":
             from src.mission_specific.pragyaan.tmtc.pragyaan_controller import PragyaanController
-            self.TMTC = PragyaanController(self.cfg["mode"]["instance_conf"], self.RM.RM_conf.yamcs_tmtc, robot_name, self.RM.robot_RG, self.RM.robot)
+
+            self.TMTC = PragyaanController(
+                self.cfg["mode"]["instance_conf"],
+                self.RM.RM_conf.yamcs_tmtc,
+                robot_name,
+                self.RM.robot_RG,
+                self.RM.robot,
+            )
         elif controller_name == "":
             raise Exception("No robot controller was setup in yaml configurations.")
-        else: 
-            raise Exception("Settings for '" + str(controller_name)  + "' robot controller are not specified.")
+        else:
+            raise Exception("Settings for '" + str(controller_name) + "' robot controller are not specified.")
 
         self.TMTC.setup_command_callbacks(self.RM.RM_conf.yamcs_tmtc["commands"])
         self.TMTC.start_streaming_data()
 
-    def _get_environment_controller(self, environment_name:str):
-        self.EC= None
+    def _get_environment_controller(self, environment_name: str):
+        self.EC = None
         if environment_name == "LargeScale":
             self.EC = LargeScaleController(
-                mode=SimulatorMode.YAMCS, **self.cfg["environment"], 
-                is_simulation_alive=self.simulation_app.is_running, 
-                close_simulation=self.simulation_app.close
+                mode=SimulatorMode.YAMCS,
+                **self.cfg["environment"],
+                is_simulation_alive=self.simulation_app.is_running,
+                close_simulation=self.simulation_app.close,
             )
         elif environment_name == "Lunaryard":
             self.EC = LunaryardController(
-                mode=SimulatorMode.YAMCS, **self.cfg["environment"], 
-                is_simulation_alive=self.simulation_app.is_running, 
-                close_simulation=self.simulation_app.close
+                mode=SimulatorMode.YAMCS,
+                **self.cfg["environment"],
+                is_simulation_alive=self.simulation_app.is_running,
+                close_simulation=self.simulation_app.close,
             )
         elif environment_name == "Lunalab":
             self.EC = LunalabController(
-                mode=SimulatorMode.YAMCS, **self.cfg["environment"], 
-                is_simulation_alive=self.simulation_app.is_running, 
-                close_simulation=self.simulation_app.close
+                mode=SimulatorMode.YAMCS,
+                **self.cfg["environment"],
+                is_simulation_alive=self.simulation_app.is_running,
+                close_simulation=self.simulation_app.close,
             )
 
         return self.EC
@@ -194,7 +205,7 @@ class Yamcs_SimulationManager:
             robot_ori = self.RM.robot_parameters.pose.orientation
             height, _ = self.EC.get_height_and_normal((robot_pos[0], robot_pos[1], 0.0))
             self.RM.preload_robot_at_pose(self.world, (robot_pos[0], robot_pos[1], height + 0.5), robot_ori)
-        
+
         else:
             self.RM.preload_robot(self.world)
 
@@ -207,11 +218,28 @@ class Yamcs_SimulationManager:
         while self.simulation_app.is_running():
             self.rate.reset()
             self.world.step(render=True)
+
             if self.world.is_playing():
-                if hasattr(self.EC, 'enable_stellar_engine') and self.EC.enable_stellar_engine:
+                did_reset = False
+
+                if hasattr(self.EC, "enable_stellar_engine") and self.EC.enable_stellar_engine:
                     self.EC.update_stellar_engine(dt=self.world.get_physics_dt())
+
                 if self.world.current_time_step_index == 0:
                     self.world.reset()
+
+                    did_reset = True
+
+                    if self.RM.robot is not None:
+                        self.RM.robot.invalidate_articulation_api()
+
+                if not did_reset and self.RM.robot is not None:
+                    self.RM.robot.update_articulation_api()
+
             self.rate.sleep()
+
+        if self.RM.robot is not None:
+            self.RM.robot.invalidate_articulation_api()
+
         self.world.stop()
         self.timeline.stop()

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -16,13 +16,28 @@ from typing import Dict, List, Optional
 
 import numpy as np
 from isaacsim.core.prims import SingleArticulation
-from isaacsim.core.utils.stage import get_current_stage
 from isaacsim.core.utils.types import ArticulationAction
 
 logger = logging.getLogger(__name__)
 
 
 class JointControlMode(str, Enum):
+    """
+    Supported joint command modes.
+
+    POSITION:
+        Command only joint position targets.
+    VELOCITY:
+        Command only joint velocity targets.
+    EFFORT:
+        Command only joint effort/torque targets.
+    MIXED:
+        Allow position, velocity, and effort targets in the same high-level
+        command. This is useful for robots where different joints are driven in
+        different ways, for example a rover with velocity-controlled wheels and
+        a position-controlled deployment mechanism such as a solar panel.
+    """
+
     POSITION = "position"
     VELOCITY = "velocity"
     EFFORT = "effort"
@@ -51,6 +66,22 @@ class JointCommandStatus:
 
 
 class ArticulationControl:
+    """
+    OmniLRS wrapper around Isaac Sim Articulation Controller.
+
+    In Isaac Sim, an articulation is a robot/mechanism made of rigid bodies
+    connected by joints and controlled from an articulation root. This class
+    wraps one robot articulation with `SingleArticulation` and applies joint
+    commands through Isaac Sim's `ArticulationAction` API.
+
+    The class is transport-agnostic and should be used through `Robot`;
+    simulation managers are responsible for initializing/updating it
+    after the world is stepped and after resets.
+
+    Isaac Sim articulation reference:
+    https://docs.isaacsim.omniverse.nvidia.com/5.0.0/robot_simulation/articulation_controller.html
+    """
+
     def __init__(
         self,
         prim_path: str,
@@ -59,6 +90,28 @@ class ArticulationControl:
         apply_period_s: float = 0.0,
         logger=logger,
     ):
+        """
+        Create an articulation joint controller.
+
+        Args:
+            prim_path:
+                USD prim path of the articulation root to control.
+            name:
+                Name assigned to the Isaac `SingleArticulation` wrapper.
+            init_retry_s:
+                Minimum wall-clock time between initialization attempts. This
+                avoids spamming Isaac initialization while the stage or physics
+                view is not ready yet.
+            apply_period_s:
+                Minimum wall-clock time between command applications. A value
+                of 0.0 means every call to `apply_command()` is allowed to send
+                an action. A positive value rate-limits command application,
+                which is useful when commands arrive faster than the desired
+                simulation/control rate.
+            logger:
+                Logger-like object used for status messages.
+        """
+
         self.prim_path = prim_path
         self.name = name
         self.init_retry_s = float(init_retry_s)
@@ -66,7 +119,6 @@ class ArticulationControl:
 
         self.log = logger.info
 
-        self.stage = None
         self.articulation: Optional[SingleArticulation] = None
 
         self.joint_names: List[str] = []
@@ -75,8 +127,6 @@ class ArticulationControl:
         self._inited = False
         self._t_last_init_try = 0.0
         self._t_last_apply = 0.0
-
-        self._pending_command: Optional[JointCommand] = None
 
         self.last_status = JointCommandStatus(
             stamp_s=0.0,
@@ -94,6 +144,21 @@ class ArticulationControl:
         return self._inited and self.articulation is not None
 
     def maybe_initialize(self) -> bool:
+        """
+        Initialize the Isaac articulation wrapper if it is not ready yet.
+
+        Returns:
+            True when the controller has a valid `SingleArticulation` wrapper
+            and joint-name/index mapping, False otherwise.
+
+        Notes:
+            This method intentionally does not read joint positions or other
+            physics state. Those reads require Isaac's physics simulation view
+            to be created, which usually happens only after the world has been
+            stepped/playing. Initialization only needs the articulation DOF
+            names so commands can later be mapped from joint names to indices.
+        """
+
         if self.is_ready:
             return True
 
@@ -103,27 +168,18 @@ class ArticulationControl:
         self._t_last_init_try = now
 
         try:
-            self.stage = get_current_stage()
-
             self.articulation = SingleArticulation(
                 prim_path=self.prim_path,
                 name=self.name,
             )
             self.articulation.initialize()
 
-            q = self._safe_array(self.articulation.get_joint_positions())
             dof_names = self.articulation.dof_names
 
             if dof_names is None:
                 raise RuntimeError(f"No DOF names found for articulation {self.prim_path}")
 
             self.joint_names = list(dof_names)
-
-            if q is not None and len(q) != len(self.joint_names):
-                raise RuntimeError(
-                    f"DOF mismatch for {self.prim_path}: " f"positions={len(q)} names={len(self.joint_names)}"
-                )
-
             self.joint_name_to_index = {name: i for i, name in enumerate(self.joint_names)}
 
             self._inited = True
@@ -138,20 +194,20 @@ class ArticulationControl:
             self.articulation = None
             return False
 
-    def set_command(self, command: JointCommand) -> None:
-        self._pending_command = command
-
-    def clear_command(self) -> None:
-        self._pending_command = None
-
-    def update(self) -> bool:
-        if self._pending_command is None:
-            return False
-
-        return self.apply_command(self._pending_command)
-
     def apply_command(self, command: JointCommand) -> bool:
-        if not self.is_ready:
+        """
+        Apply one JointCommand to the articulation.
+
+        The command is given by joint name and may contain position, velocity,
+        effort, or mixed targets. The method validates the command mode, filters
+        unknown joints, converts joint names to Isaac DOF indices, and sends the
+        corresponding `ArticulationAction`.
+
+        Returns:
+            True if at least one valid target was applied, otherwise False.
+        """
+
+        if not self.is_ready or self.articulation is None:
             return False
 
         now = time.time()
@@ -161,7 +217,7 @@ class ArticulationControl:
 
         self._t_last_apply = now
 
-        assert self.articulation is not None
+        articulation = self.articulation
 
         position_targets = dict(command.position_targets or {})
         velocity_targets = dict(command.velocity_targets or {})
@@ -186,7 +242,7 @@ class ArticulationControl:
 
         if position_targets:
             self._apply_targets(
-                articulation=self.articulation,
+                articulation=articulation,
                 kind=JointControlMode.POSITION,
                 targets=position_targets,
             )
@@ -194,7 +250,7 @@ class ArticulationControl:
 
         if velocity_targets:
             self._apply_targets(
-                articulation=self.articulation,
+                articulation=articulation,
                 kind=JointControlMode.VELOCITY,
                 targets=velocity_targets,
             )
@@ -202,7 +258,7 @@ class ArticulationControl:
 
         if effort_targets:
             self._apply_targets(
-                articulation=self.articulation,
+                articulation=articulation,
                 kind=JointControlMode.EFFORT,
                 targets=effort_targets,
             )
@@ -265,13 +321,11 @@ class ArticulationControl:
         )
 
     def close(self) -> None:
-        self.stage = None
         self.articulation = None
 
         self.joint_names = []
         self.joint_name_to_index = {}
 
-        self._pending_command = None
         self._inited = False
 
         self.last_status = JointCommandStatus(
@@ -355,12 +409,3 @@ class ArticulationControl:
             raise ValueError(f"Cannot apply target kind: {kind}")
 
         articulation.apply_action(action)
-
-    @staticmethod
-    def _safe_array(x):
-        if x is None:
-            return None
-        try:
-            return np.asarray(x)
-        except Exception:
-            return None

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 __author__ = "Shamistan Karimov, Bach Nguyen"
-__copyright__ = "Copyright 2025-26, AsteriaART/Artefacts"
+__copyright__ = "Copyright 2025-26, JAOPS, AsteriaART/Artefacts"
 __license__ = "BSD-3-Clause"
 __version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -189,7 +189,7 @@ class ArticulationControl:
             return True
 
         except Exception as e:
-            self.log(f"ArticulationControl init failed, retrying: {e}")
+            self.log(f"ArticulationControl init failed, retrying in {self.init_retry_s} s. Exception was: {e}")
             self._inited = False
             self.articulation = None
             return False

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+__author__ = "Shamistan Karimov, Bach Nguyen"
+__copyright__ = "Copyright 2025-26, AsteriaART/Artefacts"
+__license__ = "BSD-3-Clause"
+__version__ = "2.0.0"
+__maintainer__ = "Louis Burtz"
+__email__ = "ljburtz@jaops.com"
+__status__ = "development"
+
+import logging
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional
+
+import numpy as np
+from isaacsim.core.prims import SingleArticulation
+from isaacsim.core.utils.stage import get_current_stage
+from isaacsim.core.utils.types import ArticulationAction
+
+logger = logging.getLogger(__name__)
+
+
+class JointControlMode(str, Enum):
+    POSITION = "position"
+    VELOCITY = "velocity"
+    EFFORT = "effort"
+    MIXED = "mixed"
+
+
+@dataclass(frozen=True)
+class JointCommand:
+    stamp_s: float
+    mode: JointControlMode = JointControlMode.MIXED
+    position_targets: Dict[str, float] | None = None
+    velocity_targets: Dict[str, float] | None = None
+    effort_targets: Dict[str, float] | None = None
+
+
+@dataclass(frozen=True)
+class JointCommandStatus:
+    stamp_s: float
+    prim_path: str
+    mode: JointControlMode
+    applied: bool
+    unknown_joints: List[str]
+    n_position_targets: int
+    n_velocity_targets: int
+    n_effort_targets: int
+
+
+class ArticulationControl:
+    def __init__(
+        self,
+        prim_path: str,
+        name: str = "articulation_control",
+        init_retry_s: float = 0.5,
+        apply_period_s: float = 0.0,
+        logger=logger,
+    ):
+        self.prim_path = prim_path
+        self.name = name
+        self.init_retry_s = float(init_retry_s)
+        self.apply_period_s = float(apply_period_s)
+
+        self.log = logger.info
+
+        self.stage = None
+        self.articulation: Optional[SingleArticulation] = None
+
+        self.joint_names: List[str] = []
+        self.joint_name_to_index: Dict[str, int] = {}
+
+        self._inited = False
+        self._t_last_init_try = 0.0
+        self._t_last_apply = 0.0
+
+        self._pending_command: Optional[JointCommand] = None
+
+        self.last_status = JointCommandStatus(
+            stamp_s=0.0,
+            prim_path=self.prim_path,
+            mode=JointControlMode.MIXED,
+            applied=False,
+            unknown_joints=[],
+            n_position_targets=0,
+            n_velocity_targets=0,
+            n_effort_targets=0,
+        )
+
+    @property
+    def is_ready(self) -> bool:
+        return self._inited and self.articulation is not None
+
+    def maybe_initialize(self) -> bool:
+        if self.is_ready:
+            return True
+
+        now = time.time()
+        if now - self._t_last_init_try < self.init_retry_s:
+            return False
+        self._t_last_init_try = now
+
+        try:
+            self.stage = get_current_stage()
+
+            self.articulation = SingleArticulation(
+                prim_path=self.prim_path,
+                name=self.name,
+            )
+            self.articulation.initialize()
+
+            q = self._safe_array(self.articulation.get_joint_positions())
+            dof_names = self.articulation.dof_names
+
+            if dof_names is None:
+                raise RuntimeError(f"No DOF names found for articulation {self.prim_path}")
+
+            self.joint_names = list(dof_names)
+
+            if q is not None and len(q) != len(self.joint_names):
+                raise RuntimeError(
+                    f"DOF mismatch for {self.prim_path}: " f"positions={len(q)} names={len(self.joint_names)}"
+                )
+
+            self.joint_name_to_index = {name: i for i, name in enumerate(self.joint_names)}
+
+            self._inited = True
+
+            self.log(f"ArticulationControl initialized: " f"prim={self.prim_path}, dofs={len(self.joint_names)}")
+            self.log(f"DOF names: {self.joint_names}")
+            return True
+
+        except Exception as e:
+            self.log(f"ArticulationControl init failed, retrying: {e}")
+            self._inited = False
+            self.articulation = None
+            return False
+
+    def set_command(self, command: JointCommand) -> None:
+        self._pending_command = command
+
+    def clear_command(self) -> None:
+        self._pending_command = None
+
+    def update(self) -> bool:
+        if self._pending_command is None:
+            return False
+
+        return self.apply_command(self._pending_command)
+
+    def apply_command(self, command: JointCommand) -> bool:
+        if not self.is_ready:
+            return False
+
+        now = time.time()
+
+        if self.apply_period_s > 0.0 and now - self._t_last_apply < self.apply_period_s:
+            return False
+
+        self._t_last_apply = now
+
+        assert self.articulation is not None
+
+        position_targets = dict(command.position_targets or {})
+        velocity_targets = dict(command.velocity_targets or {})
+        effort_targets = dict(command.effort_targets or {})
+
+        self._validate_command_mode(
+            mode=command.mode,
+            position_targets=position_targets,
+            velocity_targets=velocity_targets,
+            effort_targets=effort_targets,
+        )
+
+        all_names = set(position_targets.keys()) | set(velocity_targets.keys()) | set(effort_targets.keys())
+
+        unknown_joints = sorted(name for name in all_names if name not in self.joint_name_to_index)
+
+        position_targets = self._filter_known_joints(position_targets)
+        velocity_targets = self._filter_known_joints(velocity_targets)
+        effort_targets = self._filter_known_joints(effort_targets)
+
+        applied = False
+
+        if position_targets:
+            self._apply_targets(
+                articulation=self.articulation,
+                kind=JointControlMode.POSITION,
+                targets=position_targets,
+            )
+            applied = True
+
+        if velocity_targets:
+            self._apply_targets(
+                articulation=self.articulation,
+                kind=JointControlMode.VELOCITY,
+                targets=velocity_targets,
+            )
+            applied = True
+
+        if effort_targets:
+            self._apply_targets(
+                articulation=self.articulation,
+                kind=JointControlMode.EFFORT,
+                targets=effort_targets,
+            )
+            applied = True
+
+        self.last_status = JointCommandStatus(
+            stamp_s=now,
+            prim_path=self.prim_path,
+            mode=command.mode,
+            applied=applied,
+            unknown_joints=unknown_joints,
+            n_position_targets=len(position_targets),
+            n_velocity_targets=len(velocity_targets),
+            n_effort_targets=len(effort_targets),
+        )
+
+        return applied
+
+    def command_positions(self, targets: Dict[str, float]) -> bool:
+        return self.apply_command(
+            JointCommand(
+                stamp_s=time.time(),
+                mode=JointControlMode.POSITION,
+                position_targets=targets,
+            )
+        )
+
+    def command_velocities(self, targets: Dict[str, float]) -> bool:
+        return self.apply_command(
+            JointCommand(
+                stamp_s=time.time(),
+                mode=JointControlMode.VELOCITY,
+                velocity_targets=targets,
+            )
+        )
+
+    def command_efforts(self, targets: Dict[str, float]) -> bool:
+        return self.apply_command(
+            JointCommand(
+                stamp_s=time.time(),
+                mode=JointControlMode.EFFORT,
+                effort_targets=targets,
+            )
+        )
+
+    def command_mixed(
+        self,
+        position_targets: Dict[str, float] | None = None,
+        velocity_targets: Dict[str, float] | None = None,
+        effort_targets: Dict[str, float] | None = None,
+    ) -> bool:
+        return self.apply_command(
+            JointCommand(
+                stamp_s=time.time(),
+                mode=JointControlMode.MIXED,
+                position_targets=position_targets or {},
+                velocity_targets=velocity_targets or {},
+                effort_targets=effort_targets or {},
+            )
+        )
+
+    def close(self) -> None:
+        self.stage = None
+        self.articulation = None
+
+        self.joint_names = []
+        self.joint_name_to_index = {}
+
+        self._pending_command = None
+        self._inited = False
+
+        self.last_status = JointCommandStatus(
+            stamp_s=0.0,
+            prim_path=self.prim_path,
+            mode=JointControlMode.MIXED,
+            applied=False,
+            unknown_joints=[],
+            n_position_targets=0,
+            n_velocity_targets=0,
+            n_effort_targets=0,
+        )
+
+        self.log(f"ArticulationControl closed: {self.prim_path}")
+
+    def _validate_command_mode(
+        self,
+        mode: JointControlMode,
+        position_targets: Dict[str, float],
+        velocity_targets: Dict[str, float],
+        effort_targets: Dict[str, float],
+    ) -> None:
+        if mode == JointControlMode.POSITION:
+            if velocity_targets or effort_targets:
+                raise ValueError("POSITION command cannot contain velocity/effort targets")
+
+        elif mode == JointControlMode.VELOCITY:
+            if position_targets or effort_targets:
+                raise ValueError("VELOCITY command cannot contain position/effort targets")
+
+        elif mode == JointControlMode.EFFORT:
+            if position_targets or velocity_targets:
+                raise ValueError("EFFORT command cannot contain position/velocity targets")
+
+        elif mode == JointControlMode.MIXED:
+            return
+
+        else:
+            raise ValueError(f"Unsupported joint control mode: {mode}")
+
+    def _filter_known_joints(self, targets: Dict[str, float]) -> Dict[str, float]:
+        return {name: value for name, value in targets.items() if name in self.joint_name_to_index}
+
+    def _apply_targets(
+        self,
+        articulation: SingleArticulation,
+        kind: JointControlMode,
+        targets: Dict[str, float],
+    ) -> None:
+        names = list(targets.keys())
+
+        indices = np.asarray(
+            [self.joint_name_to_index[name] for name in names],
+            dtype=np.int64,
+        )
+
+        values = np.asarray(
+            [targets[name] for name in names],
+            dtype=np.float32,
+        )
+
+        if kind == JointControlMode.POSITION:
+            action = ArticulationAction(
+                joint_positions=values,
+                joint_indices=indices,
+            )
+
+        elif kind == JointControlMode.VELOCITY:
+            action = ArticulationAction(
+                joint_velocities=values,
+                joint_indices=indices,
+            )
+
+        elif kind == JointControlMode.EFFORT:
+            action = ArticulationAction(
+                joint_efforts=values,
+                joint_indices=indices,
+            )
+
+        else:
+            raise ValueError(f"Cannot apply target kind: {kind}")
+
+        articulation.apply_action(action)
+
+    @staticmethod
+    def _safe_array(x):
+        if x is None:
+            return None
+        try:
+            return np.asarray(x)
+        except Exception:
+            return None

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -207,7 +207,7 @@ class ArticulationControl:
             True if at least one valid target was applied, otherwise False.
         """
 
-        if not self.is_ready or self.articulation is None:
+        if not self.is_ready:
             return False
 
         now = time.time()

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -80,6 +80,7 @@ class ArticulationControl:
 
     Isaac Sim articulation reference:
     https://docs.isaacsim.omniverse.nvidia.com/5.0.0/robot_simulation/articulation_controller.html
+    https://docs.isaacsim.omniverse.nvidia.com/5.0.0/py/source/extensions/isaacsim.core.prims/docs/index.html#isaacsim.core.prims.SingleArticulation
     """
 
     def __init__(

--- a/src/robots/articulation_telemetry.py
+++ b/src/robots/articulation_telemetry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 __author__ = "Shamistan Karimov, Bach Nguyen"
-__copyright__ = "Copyright 2025-26, AsteriaART/Artefacts"
+__copyright__ = "Copyright 2025-26, JAOPS, AsteriaART/Artefacts"
 __license__ = "BSD-3-Clause"
 __version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"

--- a/src/robots/articulation_telemetry.py
+++ b/src/robots/articulation_telemetry.py
@@ -45,6 +45,27 @@ class ArticulationTelemetryFrame:
 
 
 class ArticulationTelemetry:
+    """
+    OmniLRS wrapper for reading Isaac Sim articulation telemetry.
+
+    This class owns a `SingleArticulation` view for one robot articulation and
+    samples joint positions, joint velocities, measured efforts, and measured
+    joint/link forces.
+
+    Simulation managers should call `maybe_initialize()` and `sample()` from the
+    simulation update loop after the world has stepped. Other code should access
+    data through the cached getters such as `get_joint_positions()` and
+    `get_contact_wrenches()` instead of directly reading Isaac state.
+
+    If `keep_history` is enabled, recent joint/contact samples are stored in
+    bounded buffers. `contact_force_threshold_n` filters out contact samples
+    whose force norm is below the configured threshold.
+
+    Isaac Sim articulation reference:
+    https://docs.isaacsim.omniverse.nvidia.com/5.0.0/robot_simulation/articulation_controller.html
+    https://docs.isaacsim.omniverse.nvidia.com/5.0.0/py/source/extensions/isaacsim.core.prims/docs/index.html#isaacsim.core.prims.SingleArticulation
+    """
+
     def __init__(
         self,
         prim_path: str,
@@ -56,6 +77,29 @@ class ArticulationTelemetry:
         history_len: int = 200,
         logger=logger,
     ):
+        """
+        Create an articulation telemetry reader.
+
+        Args:
+            prim_path:
+                USD prim path of the articulation root to read.
+            name:
+                Name assigned to the Isaac `SingleArticulation` wrapper.
+            init_retry_s:
+                Minimum wall-clock time between initialization attempts.
+            sample_period_s:
+                Minimum wall-clock time between telemetry samples. A value of 0.0
+                allows every call to `sample()` to read telemetry.
+            contact_force_threshold_n:
+                Minimum contact force norm required for a contact sample to be kept.
+            keep_history:
+                If True, keep bounded joint/contact sample histories.
+            history_len:
+                Maximum number of samples stored per history buffer.
+            logger:
+                Logger-like object used for status messages.
+        """
+
         self.prim_path = prim_path
         self.name = name
         self.init_retry_s = float(init_retry_s)
@@ -81,8 +125,11 @@ class ArticulationTelemetry:
         self.joints_history: Dict[str, List[JointSample]] = {}
         self.contacts_history: Dict[str, List[ContactSample]] = {}
 
-        self.last_frame = ArticulationTelemetryFrame(
-            stamp_s=0.0,
+        self.last_frame = self._make_empty_frame()
+
+    def _make_empty_frame(self) -> ArticulationTelemetryFrame:
+        return ArticulationTelemetryFrame(
+            stamp_s=time.time(),
             prim_path=self.prim_path,
             joint_names=[],
             joints={},
@@ -110,19 +157,12 @@ class ArticulationTelemetry:
             )
             self.articulation.initialize()
 
-            q = self._safe_array(self.articulation.get_joint_positions())
             dof_names = self.articulation.dof_names
 
             if dof_names is None:
                 raise RuntimeError(f"No DOF names found for articulation {self.prim_path}")
 
             self.joint_names = list(dof_names)
-
-            if q is not None and len(q) != len(self.joint_names):
-                raise RuntimeError(
-                    f"DOF mismatch for {self.prim_path}: " f"positions={len(q)} names={len(self.joint_names)}"
-                )
-
             self.joint_name_to_index = {name: i for i, name in enumerate(self.joint_names)}
 
             if self.keep_history:
@@ -142,7 +182,21 @@ class ArticulationTelemetry:
             return False
 
     def sample(self, force: bool = False) -> Optional[ArticulationTelemetryFrame]:
-        if not self.is_ready:
+        """
+        Sample articulation telemetry from Isaac.
+
+        This reads joint positions, velocities, measured efforts, and measured
+        joint/link forces from the `SingleArticulation` view. The result is stored
+        in `last_frame` and returned to the caller.
+
+        Args:
+            force:
+                If True, ignore `sample_period_s` and sample immediately.
+
+        Returns:
+            A telemetry frame if sampling succeeded, otherwise None.
+        """
+        if not self.is_ready or self.articulation is None:
             return None
 
         now = time.time()
@@ -152,19 +206,17 @@ class ArticulationTelemetry:
 
         self._t_last_sample = now
 
-        assert self.articulation is not None
+        articulation = self.articulation
 
-        q = self._safe_array(self.articulation.get_joint_positions())
-        dq = self._safe_array(self.articulation.get_joint_velocities())
+        q = self._safe_array(articulation.get_joint_positions())
+        if q is None:
+            return None  # instead of publishing all zeros
 
-        efforts = self.articulation.get_measured_joint_efforts()
-        efforts_arr = self._safe_array(efforts) if efforts is not None else None
-
-        forces = self.articulation.get_measured_joint_forces()
-        forces_arr = self._safe_array(forces) if forces is not None else None
+        dq = self._safe_array(articulation.get_joint_velocities())
+        efforts_arr = self._safe_array(articulation.get_measured_joint_efforts())
+        forces_arr = self._safe_array(articulation.get_measured_joint_forces())
 
         forces_ready = efforts_arr is not None and forces_arr is not None
-
         joints: Dict[str, JointSample] = {}
 
         for name, i in self.joint_name_to_index.items():
@@ -250,14 +302,7 @@ class ArticulationTelemetry:
 
         self._inited = False
 
-        self.last_frame = ArticulationTelemetryFrame(
-            stamp_s=0.0,
-            prim_path=self.prim_path,
-            joint_names=[],
-            joints={},
-            contacts={},
-            forces_ready=False,
-        )
+        self.last_frame = self._make_empty_frame()
 
         self.log(f"ArticulationTelemetry closed: {self.prim_path}")
 

--- a/src/robots/articulation_telemetry.py
+++ b/src/robots/articulation_telemetry.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+__author__ = "Shamistan Karimov, Bach Nguyen"
+__copyright__ = "Copyright 2025-26, AsteriaART/Artefacts"
+__license__ = "BSD-3-Clause"
+__version__ = "2.0.0"
+__maintainer__ = "Louis Burtz"
+__email__ = "ljburtz@jaops.com"
+__status__ = "development"
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from isaacsim.core.prims import SingleArticulation
+from isaacsim.core.utils.stage import get_current_stage
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class JointSample:
+    stamp_s: float
+    position: float
+    velocity: float
+    effort: float
+
+
+@dataclass(frozen=True)
+class ContactSample:
+    stamp_s: float
+    wrench: np.ndarray
+    force_norm: float
+
+
+@dataclass(frozen=True)
+class ArticulationTelemetryFrame:
+    stamp_s: float
+    prim_path: str
+    joint_names: List[str]
+    joints: Dict[str, JointSample]
+    contacts: Dict[str, ContactSample]
+    forces_ready: bool
+
+
+class ArticulationTelemetry:
+    def __init__(
+        self,
+        prim_path: str,
+        name: str = "articulation_telemetry",
+        init_retry_s: float = 0.5,
+        sample_period_s: float = 0.0,
+        contact_force_threshold_n: float = 0.0,
+        keep_history: bool = False,
+        history_len: int = 200,
+        logger=logger,
+    ):
+        self.prim_path = prim_path
+        self.name = name
+        self.init_retry_s = float(init_retry_s)
+        self.sample_period_s = float(sample_period_s)
+        self.contact_force_threshold_n = float(max(0.0, contact_force_threshold_n))
+        self.keep_history = bool(keep_history)
+        self.history_len = int(max(1, history_len))
+
+        self.log = logger.info
+
+        self.stage = None
+        self.articulation: Optional[SingleArticulation] = None
+
+        self.joint_names: List[str] = []
+        self.joint_name_to_index: Dict[str, int] = {}
+
+        self._inited = False
+        self._t_last_init_try = 0.0
+        self._t_last_sample = 0.0
+
+        self.joints_state: Dict[str, JointSample] = {}
+        self.contacts_state: Dict[str, ContactSample] = {}
+
+        self.joints_history: Dict[str, List[JointSample]] = {}
+        self.contacts_history: Dict[str, List[ContactSample]] = {}
+
+        self.last_frame = ArticulationTelemetryFrame(
+            stamp_s=0.0,
+            prim_path=self.prim_path,
+            joint_names=[],
+            joints={},
+            contacts={},
+            forces_ready=False,
+        )
+
+    @property
+    def is_ready(self) -> bool:
+        return self._inited and self.articulation is not None
+
+    def maybe_initialize(self) -> bool:
+        if self.is_ready:
+            return True
+
+        now = time.time()
+        if now - self._t_last_init_try < self.init_retry_s:
+            return False
+        self._t_last_init_try = now
+
+        try:
+            self.stage = get_current_stage()
+
+            self.articulation = SingleArticulation(
+                prim_path=self.prim_path,
+                name=self.name,
+            )
+            self.articulation.initialize()
+
+            q = self._safe_array(self.articulation.get_joint_positions())
+            dof_names = self.articulation.dof_names
+
+            if dof_names is None:
+                raise RuntimeError(f"No DOF names found for articulation {self.prim_path}")
+
+            self.joint_names = list(dof_names)
+
+            if q is not None and len(q) != len(self.joint_names):
+                raise RuntimeError(
+                    f"DOF mismatch for {self.prim_path}: " f"positions={len(q)} names={len(self.joint_names)}"
+                )
+
+            self.joint_name_to_index = {name: i for i, name in enumerate(self.joint_names)}
+
+            if self.keep_history:
+                self.joints_history = {name: [] for name in self.joint_names}
+                self.contacts_history = {}
+
+            self._inited = True
+
+            self.log(f"ArticulationTelemetry initialized: " f"prim={self.prim_path}, dofs={len(self.joint_names)}")
+            self.log(f"DOF names: {self.joint_names}")
+            return True
+
+        except Exception as e:
+            self.log(f"ArticulationTelemetry init failed, retrying: {e}")
+            self._inited = False
+            self.articulation = None
+            return False
+
+    def sample(self, force: bool = False) -> Optional[ArticulationTelemetryFrame]:
+        if not self.is_ready:
+            return None
+
+        now = time.time()
+
+        if not force and self.sample_period_s > 0.0 and now - self._t_last_sample < self.sample_period_s:
+            return None
+
+        self._t_last_sample = now
+
+        assert self.articulation is not None
+
+        q = self._safe_array(self.articulation.get_joint_positions())
+        dq = self._safe_array(self.articulation.get_joint_velocities())
+
+        efforts = self.articulation.get_measured_joint_efforts()
+        efforts_arr = self._safe_array(efforts) if efforts is not None else None
+
+        forces = self.articulation.get_measured_joint_forces()
+        forces_arr = self._safe_array(forces) if forces is not None else None
+
+        forces_ready = efforts_arr is not None and forces_arr is not None
+
+        joints: Dict[str, JointSample] = {}
+
+        for name, i in self.joint_name_to_index.items():
+            position = float(q[i]) if q is not None and i < len(q) else 0.0
+            velocity = float(dq[i]) if dq is not None and i < len(dq) else 0.0
+            effort = float(efforts_arr[i]) if efforts_arr is not None and i < len(efforts_arr) else 0.0
+
+            sample = JointSample(
+                stamp_s=now,
+                position=position,
+                velocity=velocity,
+                effort=effort,
+            )
+
+            joints[name] = sample
+            self.joints_state[name] = sample
+
+            if self.keep_history:
+                self._append_history(self.joints_history[name], sample)
+
+        contacts: Dict[str, ContactSample] = {}
+
+        if forces_arr is not None:
+            wrenches = self._reshape_wrenches(forces_arr)
+
+            for link_i, wrench in enumerate(wrenches):
+                wrench = wrench.astype(np.float32, copy=False)
+                force_norm = float(np.linalg.norm(wrench[:3]))
+
+                if force_norm < self.contact_force_threshold_n:
+                    continue
+
+                name = f"link_{link_i}"
+
+                sample = ContactSample(
+                    stamp_s=now,
+                    wrench=wrench.copy(),
+                    force_norm=force_norm,
+                )
+
+                contacts[name] = sample
+                self.contacts_state[name] = sample
+
+                if self.keep_history:
+                    if name not in self.contacts_history:
+                        self.contacts_history[name] = []
+                    self._append_history(self.contacts_history[name], sample)
+
+        frame = ArticulationTelemetryFrame(
+            stamp_s=now,
+            prim_path=self.prim_path,
+            joint_names=list(self.joint_names),
+            joints=joints,
+            contacts=contacts,
+            forces_ready=forces_ready,
+        )
+
+        self.last_frame = frame
+        return frame
+
+    def get_joint_positions(self) -> Dict[str, float]:
+        return {name: sample.position for name, sample in self.last_frame.joints.items()}
+
+    def get_joint_velocities(self) -> Dict[str, float]:
+        return {name: sample.velocity for name, sample in self.last_frame.joints.items()}
+
+    def get_joint_efforts(self) -> Dict[str, float]:
+        return {name: sample.effort for name, sample in self.last_frame.joints.items()}
+
+    def get_contact_wrenches(self) -> Dict[str, np.ndarray]:
+        return {name: sample.wrench for name, sample in self.last_frame.contacts.items()}
+
+    def close(self) -> None:
+        self.stage = None
+        self.articulation = None
+
+        self.joint_names = []
+        self.joint_name_to_index = {}
+
+        self.joints_state.clear()
+        self.contacts_state.clear()
+        self.joints_history.clear()
+        self.contacts_history.clear()
+
+        self._inited = False
+
+        self.last_frame = ArticulationTelemetryFrame(
+            stamp_s=0.0,
+            prim_path=self.prim_path,
+            joint_names=[],
+            joints={},
+            contacts={},
+            forces_ready=False,
+        )
+
+        self.log(f"ArticulationTelemetry closed: {self.prim_path}")
+
+    def _append_history(self, buf: List[Any], item: Any) -> None:
+        buf.append(item)
+        if len(buf) > self.history_len:
+            del buf[: len(buf) - self.history_len]
+
+    @staticmethod
+    def _safe_array(x):
+        if x is None:
+            return None
+        try:
+            return np.asarray(x)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _reshape_wrenches(forces_arr: np.ndarray) -> np.ndarray:
+        a = np.asarray(forces_arr)
+
+        while a.ndim > 2 and a.shape[-1] == 1:
+            a = a[..., 0]
+
+        if a.ndim == 2 and a.shape[1] == 6:
+            return a
+
+        if a.ndim == 1 and a.size % 6 == 0:
+            return a.reshape((-1, 6))
+
+        a = a.reshape((a.shape[0], -1))
+
+        if a.shape[1] >= 6:
+            return a[:, :6]
+
+        return np.zeros((0, 6), dtype=np.float32)

--- a/src/robots/articulation_telemetry.py
+++ b/src/robots/articulation_telemetry.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 from isaacsim.core.prims import SingleArticulation
-from isaacsim.core.utils.stage import get_current_stage
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,6 @@ class ArticulationTelemetry:
 
         self.log = logger.info
 
-        self.stage = None
         self.articulation: Optional[SingleArticulation] = None
 
         self.joint_names: List[str] = []
@@ -106,8 +104,6 @@ class ArticulationTelemetry:
         self._t_last_init_try = now
 
         try:
-            self.stage = get_current_stage()
-
             self.articulation = SingleArticulation(
                 prim_path=self.prim_path,
                 name=self.name,
@@ -242,7 +238,6 @@ class ArticulationTelemetry:
         return {name: sample.wrench for name, sample in self.last_frame.contacts.items()}
 
     def close(self) -> None:
-        self.stage = None
         self.articulation = None
 
         self.joint_names = []

--- a/src/robots/articulation_telemetry.py
+++ b/src/robots/articulation_telemetry.py
@@ -140,7 +140,7 @@ class ArticulationTelemetry:
             return True
 
         except Exception as e:
-            self.log(f"ArticulationTelemetry init failed, retrying: {e}")
+            self.log(f"ArticulationTelemetry init failed, retrying in {self.init_retry_s} s. Exception was: {e}")
             self._inited = False
             self.articulation = None
             return False

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -58,8 +58,8 @@ class RobotManager:
         self.robot_parameters = self.RM_conf.parameters
         self.robots_root = self.RM_conf.robots_root
         createXform(self.stage, self.robots_root)
-        self.robot: Robot = None  # TODO for v4: if only 1 robot, no need for a dict, just an instance
-        self.robot_RG: RobotRigidGroup = None  # TODO for v4: if only 1 robot, no need for a dict, just an instance
+        self.robot: Robot = None
+        self.robot_RG: RobotRigidGroup = None
 
     def preload_robot(
         self,
@@ -285,11 +285,6 @@ class Robot:
             from src.mission_specific.pragyaan.subsystems.pragyaan_subsystems_handler import PragyaanSubsystemsHandler
 
             self.subsystems = PragyaanSubsystemsHandler(pos_relative_to_prim)
-
-        elif robot_name == "pioneer":
-            from src.mission_specific.pioneer.subsystems.pioneer_subsystems_handler import PioneerSubsystemsHandler
-
-            self.subsystems = PioneerSubsystemsHandler(pos_relative_to_prim)
 
     def edit_graphs(self) -> None:
         """
@@ -814,7 +809,7 @@ class RobotRigidGroup:
         Initialize the rigidprims and rigidprimviews of the robot.
 
         Args:
-            world (World): A Omni.isaac.core.world.World object.
+            world (World): A isaacsim.core.api.world.World object.
         """
 
         self.dt = world.get_physics_dt()

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -398,58 +398,25 @@ class Robot:
     def _initialize_cameras(self) -> None:
         # Camera is a wrapper, therefore it just wraps around the camera instance if it already exists
         # otherwise it creates a new camera instance on the provided prim_path
+        if "resolutions" not in self._camera_conf:
+            return
 
-        if isinstance(self._camera_conf, list):
-            self._cameras = []
-            self._depth_cameras = []
+        resolutions = list(self._camera_conf.get("resolutions").keys())
 
-            for camera_conf in self._camera_conf:
-                if "resolutions" not in camera_conf:
-                    continue
+        for res in resolutions:
+            self._cameras[res] = Camera(
+                self._camera_conf["prim_path"],
+                resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]),
+            )
+            self._cameras[res].initialize()
 
-                camera = {}
-                depth_camera = {}
-
-                resolutions = list(camera_conf.get("resolutions").keys())
-
-                for res in resolutions:
-                    camera[res] = Camera(
-                        camera_conf["prim_path"],
-                        resolution=(camera_conf["resolutions"][res][0], camera_conf["resolutions"][res][1]),
-                    )
-                    camera[res].initialize()
-
-                for res in resolutions:
-                    depth_camera[res] = Camera(
-                        camera_conf["prim_path"],
-                        resolution=(camera_conf["resolutions"][res][0], camera_conf["resolutions"][res][1]),
-                    )
-                    depth_camera[res].initialize()
-                    depth_camera[res].add_distance_to_image_plane_to_frame()
-
-                self._cameras.append(camera)
-                self._depth_cameras.append(depth_camera)
-
-        else:
-            if "resolutions" not in self._camera_conf:
-                return
-
-            resolutions = list(self._camera_conf.get("resolutions").keys())
-
-            for res in resolutions:
-                self._cameras[res] = Camera(
-                    self._camera_conf["prim_path"],
-                    resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]),
-                )
-                self._cameras[res].initialize()
-
-            for res in resolutions:
-                self._depth_cameras[res] = Camera(
-                    self._camera_conf["prim_path"],
-                    resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]),
-                )
-                self._depth_cameras[res].initialize()
-                self._depth_cameras[res].add_distance_to_image_plane_to_frame()
+        for res in resolutions:
+            self._depth_cameras[res] = Camera(
+                self._camera_conf["prim_path"],
+                resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]),
+            )
+            self._depth_cameras[res].initialize()
+            self._depth_cameras[res].add_distance_to_image_plane_to_frame()
 
     def get_rgba_camera_view(self, resolution) -> np.ndarray:
         return self._cameras[resolution].get_rgba()

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -1,4 +1,4 @@
-__author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk"
+__author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk, Shamistan Karimov"
 __copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
 __license__ = "BSD-3-Clause"
 __version__ = "2.0.0"
@@ -7,37 +7,33 @@ __email__ = "ljburtz@jaops.com"
 __status__ = "development"
 
 import math
-import threading
-import time
-from typing import Dict, List, Tuple
-from scipy.spatial.transform import Rotation as R
-import numpy as np
-import warnings
 import os
+from typing import Dict, List, Tuple
 
-import omni
-from isaacsim.core.api.world import World
-import omni.graph.core as og
-from isaacsim.core.utils.rotations import quat_to_rot_matrix
-from omni.isaac.dynamic_control import _dynamic_control #TODO deprecated
-from isaacsim.core.prims import SingleRigidPrim, SingleXFormPrim, RigidPrim
-from pxr import Gf, Usd
-
-from WorldBuilders.pxr_utils import createXform, createObject
-from src.configurations.robot_confs import RobotManagerConf
 import numpy as np
-from scipy.spatial.transform import Rotation as R
+import omni
+import omni.graph.core as og
+from isaacsim.core.api.world import World
+from isaacsim.core.prims import RigidPrim, SingleRigidPrim, SingleXFormPrim
+from isaacsim.core.utils.rotations import quat_to_rot_matrix
 
-from src.configurations.simulator_mode_enum import SimulatorMode
-from src.environments.utils import transform_orientation_from_xyzw_into_xyz, transform_orientation_into_xyz
-from src.subsystems.robot_subsystems_handler import RobotSubsystemsHandler
 # from src.robots.subsystems_manager import RobotSubsystemsManager
 from isaacsim.sensors.camera import Camera
-
 from isaacsim.sensors.physics import _sensor
+from pxr import Gf, Usd
+from scipy.spatial.transform import Rotation as R
 
-#TODO for v4: rethink which methods should be in Manager, RRG, what should be in Robot
-#TODO for v4: separate into a different file (very complex and lengthy classes)
+from src.configurations.robot_confs import RobotManagerConf
+from src.configurations.simulator_mode_enum import SimulatorMode
+from src.environments.utils import transform_orientation_from_xyzw_into_xyz, transform_orientation_into_xyz
+from src.robots.articulation_control import ArticulationControl
+from src.robots.articulation_telemetry import ArticulationTelemetry
+from src.subsystems.robot_subsystems_handler import RobotSubsystemsHandler
+from WorldBuilders.pxr_utils import createObject, createXform
+
+
+# TODO for v4: rethink which methods should be in Manager, RRG, what should be in Robot
+# TODO for v4: separate into a different file (very complex and lengthy classes)
 class RobotManager:
     """
     RobotManager class.
@@ -47,21 +43,23 @@ class RobotManager:
     def __init__(
         self,
         RM_conf: RobotManagerConf,
-        mode:SimulatorMode = SimulatorMode.ROS2,
+        mode: SimulatorMode = SimulatorMode.ROS2,
     ) -> None:
         """
         Args:
             RM_conf (RobotManagerConf): The configuration of the robot manager.
         """
 
-        self.stage = omni.usd.get_context().get_stage() # TODO for v4: logcally an instance of a robot, should not have access to the instance of stage... change?
+        self.stage = (
+            omni.usd.get_context().get_stage()
+        )  # TODO for v4: logcally an instance of a robot, should not have access to the instance of stage... change?
         self.RM_conf = RobotManagerConf(**RM_conf)
         self.is_ROS2 = mode == SimulatorMode.ROS2
         self.robot_parameters = self.RM_conf.parameters
         self.robots_root = self.RM_conf.robots_root
         createXform(self.stage, self.robots_root)
-        self.robot: Robot = None   
-        self.robot_RG: RobotRigidGroup = None
+        self.robot: Robot = None  # TODO for v4: if only 1 robot, no need for a dict, just an instance
+        self.robot_RG: RobotRigidGroup = None  # TODO for v4: if only 1 robot, no need for a dict, just an instance
 
     def preload_robot(
         self,
@@ -72,6 +70,10 @@ class RobotManager:
         Args:
             world (Usd.Stage): The usd stage scene.
         """
+        print("self.robot_parameters")
+
+        print(self.robot_parameters)
+
         self.add_robot(
             self.robot_parameters.usd_path,
             self.robot_parameters.robot_name,
@@ -135,12 +137,12 @@ class RobotManager:
         q: Tuple[float, float, float, float] = [0, 0, 0, 1],
         domain_id: int = None,
         wheel_joints: dict = {},
-        camera_conf :dict={},
-        imu_sensor_path:str="",
-        dimensions:dict={},
-        turn_speed_coef:float=1,
-        pos_relative_to_prim:str="",
-        solar_panel_joint:str="",
+        camera_conf: dict = {},
+        imu_sensor_path: str = "",
+        dimensions: dict = {},
+        turn_speed_coef: float = 1,
+        pos_relative_to_prim: str = "",
+        solar_panel_joint: str = "",
     ) -> None:
         """
         Add a robot to the scene.
@@ -178,7 +180,7 @@ class RobotManager:
         robot_name: str = None,
         target_links: List[str] = None,
         pose_base_link: str = None,
-        world = None,
+        world=None,
     ) -> None:
         """
         Add a robot rigid group to the scene.
@@ -203,13 +205,12 @@ class RobotManager:
         """
         self.robot.reset()
 
-    def teleport_robot(
-        self, position: np.ndarray = None, orientation: np.ndarray = None
-    ) -> None:
+    def teleport_robot(self, position: np.ndarray = None, orientation: np.ndarray = None) -> None:
         """
         Teleport the robot to a specific position and orientation.
         """
         self.robot.teleport(position, orientation)
+
 
 class Robot:
     """
@@ -218,8 +219,8 @@ class Robot:
     and tfs to enable multi-robot operation.
     """
 
-    #TODO for v4: simplify and refactor the initialization, put some inits into a separate init methods, 
-    #TODO for v4: lower the number of arguments, simplify
+    # TODO for v4: simplify and refactor the initialization, put some inits into a separate init methods,
+    # TODO for v4: lower the number of arguments, simplify
     def __init__(
         self,
         usd_path: str,
@@ -228,13 +229,12 @@ class Robot:
         is_ROS2: bool = False,
         domain_id: int = 0,
         wheel_joints: Dict = {},
-        camera_conf:Dict = {},
-        imu_sensor_path:str = "",
-        dimensions:dict = {},
-        turn_speed_coef:float=1,
-        pos_relative_to_prim:str = "",
-        solar_panel_joint:str = "",
-
+        camera_conf: Dict = {},
+        imu_sensor_path: str = "",
+        dimensions: dict = {},
+        turn_speed_coef: float = 1,
+        pos_relative_to_prim: str = "",
+        solar_panel_joint: str = "",
     ) -> None:
         """
         Args:
@@ -251,39 +251,45 @@ class Robot:
         self.robot_path = os.path.join(self.robots_root, self.robot_name.strip("/"))
         self.is_ROS2 = is_ROS2
         self.domain_id = int(domain_id)
-        self.dc = _dynamic_control.acquire_dynamic_control_interface()
-        self.root_body_id = None
-        self._wheel_joint_names = wheel_joints
-        self._dofs = {} # dof = Degree of Freedom
+        self._wheel_joint_names = wheel_joints or {}
+        self.telemetry = ArticulationTelemetry(
+            prim_path=self.robot_path,
+            name=f"{self.robot_name.strip('/')}_telemetry",
+            sample_period_s=0.0,
+        )
+        self.control = ArticulationControl(
+            prim_path=self.robot_path,
+            name=f"{self.robot_name.strip('/')}_control",
+            apply_period_s=0.0,
+        )
+        self._articulation_api_enabled = False
+        self._last_joint_positions: dict[str, float] = {}
+        self._last_joint_velocities: dict[str, float] = {}
+        self._last_joint_efforts: dict[str, float] = {}
+        self._last_wheel_joint_angles: list[float] = []
         self._camera_conf = camera_conf
         self._cameras = {}
         self._depth_cameras = {}
         self.dimensions = dimensions
         self.turn_speed_coef = turn_speed_coef
         self._imu_sensor_interface = _sensor.acquire_imu_sensor_interface()
-        self._imu_sensor_path:str = imu_sensor_path
+        self._imu_sensor_path: str = imu_sensor_path
         self._solar_panel_joint = solar_panel_joint
-        self._solar_panel_dof = None
         self._setup_subsystems_handler(pos_relative_to_prim)
 
     def _setup_subsystems_handler(self, pos_relative_to_prim):
-        self.subsystems:RobotSubsystemsHandler = None
+        self.subsystems: RobotSubsystemsHandler = None
         robot_name = self.robot_name.strip("/")
-        
+
         if robot_name == "pragyaan":
             from src.mission_specific.pragyaan.subsystems.pragyaan_subsystems_handler import PragyaanSubsystemsHandler
+
             self.subsystems = PragyaanSubsystemsHandler(pos_relative_to_prim)
 
-    def get_root_rigid_body_path(self) -> None:
-        """
-        Get the root rigid body path of the robot.
-        """
+        elif robot_name == "pioneer":
+            from src.mission_specific.pioneer.subsystems.pioneer_subsystems_handler import PioneerSubsystemsHandler
 
-        art = self.dc.get_articulation(self.robot_path)
-        self.root_body_id = self.dc.get_articulation_root_body(art)
-
-    def _get_art(self):
-        return self.dc.get_articulation(self.robot_path)
+            self.subsystems = PioneerSubsystemsHandler(pos_relative_to_prim)
 
     def edit_graphs(self) -> None:
         """
@@ -324,70 +330,222 @@ class Robot:
         self.edit_graphs()
         self._initialize_cameras()
 
+    def is_articulation_api_ready(self) -> bool:
+        return self._articulation_api_enabled
+
+    def update_articulation_api(self) -> None:
+        """
+        Call this from the simulation update loop after timeline.play().
+        This is the only place where Robot should actively update articulation-backed state.
+        """
+        control_ready = self.control.maybe_initialize()
+        telemetry_ready = self.telemetry.maybe_initialize()
+
+        if not control_ready or not telemetry_ready:
+            self._articulation_api_enabled = False
+            return
+
+        frame = self.telemetry.sample()
+        if frame is None:
+            self._articulation_api_enabled = False
+            return
+
+        self._articulation_api_enabled = True
+
+        self._last_joint_positions = {name: sample.position for name, sample in frame.joints.items()}
+        self._last_joint_velocities = {name: sample.velocity for name, sample in frame.joints.items()}
+        self._last_joint_efforts = {name: sample.effort for name, sample in frame.joints.items()}
+
+        self.update_wheel_joint_angles()
+
+    def update_wheel_joint_angles(self) -> None:
+        """
+        Update cached wheel joint angles from the latest articulation telemetry.
+
+        This should not call Isaac directly.
+        It only uses self._last_joint_positions, which is updated by update_articulation_api().
+        """
+        if not self._wheel_joint_names:
+            self._last_wheel_joint_angles = []
+            return
+
+        joint_angles = []
+
+        for side in ["left", "right"]:
+            for joint_name in self._wheel_joint_names.get(side, []):
+                joint_angles.append(float(self._last_joint_positions.get(joint_name, 0.0)))
+
+        self._last_wheel_joint_angles = joint_angles
+
+    def invalidate_articulation_api(self) -> None:
+        """
+        Call after world.reset() or when physics views may have been invalidated.
+        """
+        self._articulation_api_enabled = False
+
+        self._last_joint_positions = {}
+        self._last_joint_velocities = {}
+        self._last_joint_efforts = {}
+        self._last_wheel_joint_angles = []
+
+        try:
+            self.control.close()
+        except Exception:
+            pass
+
+        try:
+            self.telemetry.close()
+        except Exception:
+            pass
+
     def get_streaming_cam_resolution(self):
         return (self._camera_conf["resolutions"]["low"][0], self._camera_conf["resolutions"]["low"][1])
-    
+
     def get_high_cam_resolution(self):
         return (self._camera_conf["resolutions"]["high"][0], self._camera_conf["resolutions"]["high"][1])
-        
+
     def _initialize_cameras(self) -> None:
         # Camera is a wrapper, therefore it just wraps around the camera instance if it already exists
         # otherwise it creates a new camera instance on the provided prim_path
-        if "resolutions" not in self._camera_conf:
-            return
-        
-        resolutions = list(self._camera_conf.get("resolutions").keys())
 
-        for res in resolutions:
-            self._cameras[res] = Camera(self._camera_conf["prim_path"], 
-                                resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]))
-            self._cameras[res].initialize()
+        if isinstance(self._camera_conf, list):
+            self._cameras = []
+            self._depth_cameras = []
 
-        for res in resolutions:
-            self._depth_cameras[res] = Camera(self._camera_conf["prim_path"], 
-                                resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]))
-            self._depth_cameras[res].initialize()
-            self._depth_cameras[res].add_distance_to_image_plane_to_frame()
+            for camera_conf in self._camera_conf:
+                if "resolutions" not in camera_conf:
+                    continue
+
+                camera = {}
+                depth_camera = {}
+
+                resolutions = list(camera_conf.get("resolutions").keys())
+
+                for res in resolutions:
+                    camera[res] = Camera(
+                        camera_conf["prim_path"],
+                        resolution=(camera_conf["resolutions"][res][0], camera_conf["resolutions"][res][1]),
+                    )
+                    camera[res].initialize()
+
+                for res in resolutions:
+                    depth_camera[res] = Camera(
+                        camera_conf["prim_path"],
+                        resolution=(camera_conf["resolutions"][res][0], camera_conf["resolutions"][res][1]),
+                    )
+                    depth_camera[res].initialize()
+                    depth_camera[res].add_distance_to_image_plane_to_frame()
+
+                self._cameras.append(camera)
+                self._depth_cameras.append(depth_camera)
+
+        else:
+            if "resolutions" not in self._camera_conf:
+                return
+
+            resolutions = list(self._camera_conf.get("resolutions").keys())
+
+            for res in resolutions:
+                self._cameras[res] = Camera(
+                    self._camera_conf["prim_path"],
+                    resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]),
+                )
+                self._cameras[res].initialize()
+
+            for res in resolutions:
+                self._depth_cameras[res] = Camera(
+                    self._camera_conf["prim_path"],
+                    resolution=(self._camera_conf["resolutions"][res][0], self._camera_conf["resolutions"][res][1]),
+                )
+                self._depth_cameras[res].initialize()
+                self._depth_cameras[res].add_distance_to_image_plane_to_frame()
 
     def get_rgba_camera_view(self, resolution) -> np.ndarray:
         return self._cameras[resolution].get_rgba()
-    
+
+    def get_rgba_camera_view_by_idx(self, idx, resolution) -> np.ndarray:
+        return self._cameras[idx][resolution].get_rgba()
+
     def get_depth_camera_view(self, resolution) -> np.ndarray:
         """Returns depth image in meters as (H, W) float32 array."""
         depth = self._depth_cameras[resolution].get_depth()
         print("depth")
         print(depth)
         return depth
-    
+
     def get_imu_readings(self):
-        if (self._imu_sensor_path == ""):
-            raise Exception("Path to imu sensor is not defined. Please check your .yaml configuration file. 'imu_sensor_path' should be defined on the same level as 'robot_name'.")
-        
+        if self._imu_sensor_path == "":
+            raise Exception(
+                "Path to imu sensor is not defined. Please check your .yaml configuration file. 'imu_sensor_path' should be defined on the same level as 'robot_name'."
+            )
+
         # https://docs.isaacsim.omniverse.nvidia.com/4.5.0/sensors/isaacsim_sensors_physics_imu.html#reading-sensor-output
-        sensor_reading = self._imu_sensor_interface.get_sensor_reading(self._imu_sensor_path, use_latest_data = True, read_gravity = True)
-        linear_acceleration = {"ax": sensor_reading.lin_acc_x, "ay": sensor_reading.lin_acc_y, "az": sensor_reading.lin_acc_z}
-        angular_velocity = {"gx":sensor_reading.ang_vel_x, "gy":sensor_reading.ang_vel_y, "gz":sensor_reading.ang_vel_z} 
-        
-        # orientation = sensor_reading.orientation # w, x, y, z 
-        orientation = sensor_reading.orientation # x, y, z, w
-        xyz_orientation = transform_orientation_from_xyzw_into_xyz(orientation) 
-        orientation = {"roll":-float(xyz_orientation[0]), "pitch":-float(xyz_orientation[1]), "yaw":float(xyz_orientation[2])}
+        sensor_reading = self._imu_sensor_interface.get_sensor_reading(
+            self._imu_sensor_path, use_latest_data=True, read_gravity=True
+        )
+        linear_acceleration = {
+            "ax": sensor_reading.lin_acc_x,
+            "ay": sensor_reading.lin_acc_y,
+            "az": sensor_reading.lin_acc_z,
+        }
+        angular_velocity = {
+            "gx": sensor_reading.ang_vel_x,
+            "gy": sensor_reading.ang_vel_y,
+            "gz": sensor_reading.ang_vel_z,
+        }
 
-        # print(linear_acceleration, angular_velocity, orientation)
+        # orientation = sensor_reading.orientation # w, x, y, z
+
+        raw_orientation = np.asarray(sensor_reading.orientation, dtype=float)
+
+        if raw_orientation.shape != (4,):
+            print(f"[WARN] Invalid IMU orientation shape: {raw_orientation}")
+            xyz_orientation = np.zeros(3)
+
+        elif np.linalg.norm(raw_orientation) < 1e-8:
+            print(
+                f"[WARN] IMU returned zero quaternion at path "
+                f"{self._imu_sensor_path}: {raw_orientation}. "
+                "Sensor is probably not initialized yet."
+            )
+            xyz_orientation = np.zeros(3)
+
+        else:
+            raw_orientation = raw_orientation / np.linalg.norm(raw_orientation)
+
+            xyz_orientation = transform_orientation_from_xyzw_into_xyz(raw_orientation)
+
+        orientation = {
+            "roll": -float(xyz_orientation[0]),
+            "pitch": -float(xyz_orientation[1]),
+            "yaw": float(xyz_orientation[2]),
+        }
+
         return linear_acceleration, angular_velocity, orientation
-
 
     def get_pose(self) -> List[float]:
         """
-        Get the pose of the robot.
+        Get the pose of the robot root.
+
         Returns:
-            List[float]: The pose of the robot. (x, y, z), (qx, qy, qz, qw)
+            position, orientation_xyzw
         """
-        if self.root_body_id is None:
-            self.get_root_rigid_body_path()
-        pose = self.dc.get_rigid_body_pose(self.root_body_id)
-        return pose.p, pose.r
-    
+        if not self._articulation_api_enabled or self.telemetry.articulation is None:
+            raise RuntimeError(
+                f"Articulation API is not ready: {self.robot_path}. "
+                "Call update_articulation_api() from the simulation loop first."
+            )
+
+        position, quat_wxyz = self.telemetry.articulation.get_world_pose()
+
+        quat_xyzw = [
+            float(quat_wxyz[1]),
+            float(quat_wxyz[2]),
+            float(quat_wxyz[3]),
+            float(quat_wxyz[0]),
+        ]
+
+        return position, quat_xyzw
 
     def set_reset_pose(self, position: np.ndarray, orientation: np.ndarray) -> None:
         """
@@ -406,26 +564,49 @@ class Robot:
         Teleport the robot to a specific position and orientation.
 
         Args:
-            p (list): The position of the robot.
-            q (list): The orientation of the robot. (x, y, z, w)
+            p: position [x, y, z]
+            q: orientation [x, y, z, w]
         """
+        if not self._articulation_api_enabled or self.control.articulation is None:
+            raise RuntimeError(
+                f"Articulation API is not ready: {self.robot_path}. "
+                "Call update_articulation_api() from the simulation loop first."
+            )
 
-        self.get_root_rigid_body_path()
-        transform = _dynamic_control.Transform(p, q)
-        self.dc.set_rigid_body_pose(self.root_body_id, transform)
-        self.dc.set_rigid_body_linear_velocity(self.root_body_id, [0, 0, 0])
-        self.dc.set_rigid_body_angular_velocity(self.root_body_id, [0, 0, 0])
+        quat_wxyz = np.asarray([q[3], q[0], q[1], q[2]], dtype=np.float32)
+        position = np.asarray(p, dtype=np.float32)
+
+        self.control.articulation.set_world_pose(
+            position=position,
+            orientation=quat_wxyz,
+        )
+
+        self.control.articulation.set_linear_velocity(np.zeros(3, dtype=np.float32))
+        self.control.articulation.set_angular_velocity(np.zeros(3, dtype=np.float32))
+
+        self._last_joint_positions = {}
+        self._last_joint_velocities = {}
+        self._last_joint_efforts = {}
+        self._last_wheel_joint_angles = []
 
     def reset(self) -> None:
         """
         Reset the robot to its original position and orientation.
-        """
 
-        # w = self.reset_orientation.GetReal()
-        # xyz = self.reset_orientation.GetImaginary()
-        self.root_body_id = None
+        Note:
+            This requires articulation API to be ready. If called during world reset,
+            queue this from the simulation manager after update_articulation_api() succeeds.
+        """
+        if not self._articulation_api_enabled:
+            print(f"Cannot reset robot yet. Articulation API is not ready: {self.robot_path}")
+            return
+
         self.teleport(
-            [self.reset_position[0], self.reset_position[1], self.reset_position[2]],
+            [
+                self.reset_position[0],
+                self.reset_position[1],
+                self.reset_position[2],
+            ],
             [
                 self.reset_orientation[1],
                 self.reset_orientation[2],
@@ -435,96 +616,184 @@ class Robot:
         )
 
     def drive_straight(self, linear_velocity):
-        self._set_wheels_velocity(linear_velocity, "left")
-        self._set_wheels_velocity(linear_velocity, "right")
+        left_ok = self._set_wheels_velocity(linear_velocity, "left")
+        right_ok = self._set_wheels_velocity(linear_velocity, "right")
+        return bool(left_ok and right_ok)
 
     def drive_turn(self, wheel_speed):
         print(wheel_speed)
-        if (wheel_speed > 0):
+        if wheel_speed > 0:
             print("turns left")
         else:
             print("turns right")
-        self._set_wheels_velocity(-wheel_speed, "left")
-        self._set_wheels_velocity(wheel_speed, "right")
+
+        left_ok = self._set_wheels_velocity(-wheel_speed, "left")
+        right_ok = self._set_wheels_velocity(wheel_speed, "right")
+        return bool(left_ok and right_ok)
 
     def stop_drive(self):
-        self._set_wheels_velocity(0, "left")
-        self._set_wheels_velocity(0, "right")
+        left_ok = self._set_wheels_velocity(0.0, "left")
+        right_ok = self._set_wheels_velocity(0.0, "right")
+        return bool(left_ok and right_ok)
 
-    def _set_wheels_velocity(self, velocity, side:str):
-        self._init_dofs()
+    def set_joint_positions(self, targets: dict[str, float]) -> bool:
+        """
+        Command joint position targets by joint name.
 
-        if side not in ["left","right"]:
+        Args:
+            targets:
+                {
+                    "joint_name": position_rad_or_m,
+                    ...
+                }
+        """
+        if not self._articulation_api_enabled:
+            print(f"Articulation API is not ready: {self.robot_path}")
+            return False
+
+        return self.control.command_positions(targets)
+
+    def set_joint_velocities(self, targets: dict[str, float]) -> bool:
+        """
+        Command joint velocity targets by joint name.
+
+        Args:
+            targets:
+                {
+                    "joint_name": velocity_rad_s_or_m_s,
+                    ...
+                }
+        """
+        if not self._articulation_api_enabled:
+            print(f"Articulation API is not ready: {self.robot_path}")
+            return False
+
+        return self.control.command_velocities(targets)
+
+    def set_joint_efforts(self, targets: dict[str, float]) -> bool:
+        """
+        Command joint effort targets by joint name.
+
+        Args:
+            targets:
+                {
+                    "joint_name": effort_Nm_or_N,
+                    ...
+                }
+        """
+        if not self._articulation_api_enabled:
+            print(f"Articulation API is not ready: {self.robot_path}")
+            return False
+
+        return self.control.command_efforts(targets)
+
+    def set_joint_targets(
+        self,
+        *,
+        position_targets: dict[str, float] | None = None,
+        velocity_targets: dict[str, float] | None = None,
+        effort_targets: dict[str, float] | None = None,
+    ) -> bool:
+        """
+        Mixed joint command.
+
+        Useful when some joints are position-controlled and others are velocity/effort-controlled.
+        """
+        if not self._articulation_api_enabled:
+            print(f"Articulation API is not ready: {self.robot_path}")
+            return False
+
+        return self.control.command_mixed(
+            position_targets=position_targets or {},
+            velocity_targets=velocity_targets or {},
+            effort_targets=effort_targets or {},
+        )
+
+    def _set_wheels_velocity(self, velocity, side: str):
+        if not self._wheel_joint_names:
+            return False
+
+        if side not in ["left", "right"]:
             print("Wrong side param:", side, "Side can only be [left] or [right].")
-            return
+            return False
 
-        for dof in self._dofs[side]:
-            self.dc.set_dof_velocity_target(dof, velocity)
+        targets = {joint_name: float(velocity) for joint_name in self._wheel_joint_names.get(side, [])}
+
+        return self.set_joint_velocities(targets)
 
     def get_wheels_joint_angles(self):
-        self._init_dofs()
-        
-        joint_angles = []
-        for side in ["left","right"]:
-            for dof in self._dofs[side]:
-                joint_angle = self.dc.get_dof_position(dof)
-                joint_angles.append(joint_angle)
+        return list(self._last_wheel_joint_angles)
 
-        return joint_angles
-
-    def _init_dofs(self):
-        #NOTE idealy, this would be initialized inside load(),
-        # however, for an unknown reason art, and dc do not work well when invoked there
-        # thus not populating dofs correctly
-        # therefore, it was implemented as singleton, and should be called at the begging of every commanding function
-        #
-        # more about the use of dofs for robot movement can be read on: 
-        # https://docs.isaacsim.omniverse.nvidia.com/5.0.0/python_scripting/robots_simulation.html#velocity-control
+    def get_wheel_joint_names(self, side: str | None = None) -> list[str]:
         if not self._wheel_joint_names:
-            return
+            return []
 
-        if "left" in list(self._dofs.keys()):
-            return # it means it is already initialized
-        
-        self._dofs = {
-            "left": [],
-            "right": []
-        }
-        art = self._get_art()
+        if side is None:
+            names = []
+            for rover_side in ["left", "right"]:
+                names.extend(self._wheel_joint_names.get(rover_side, []))
+            return names
 
-        for rover_side in ["left", "right"]:
-            for joint_name in self._wheel_joint_names[rover_side]:
-                dof = self.dc.find_articulation_dof(art, joint_name)
-                self._dofs[rover_side].append(dof)
+        if side not in ["left", "right"]:
+            raise ValueError("side must be 'left', 'right', or None")
 
-    def _init_solar_panel_dof(self):
-        if self._solar_panel_dof == None and self._solar_panel_joint != "":
-            art = self._get_art()
-            self._solar_panel_dof = self.dc.find_articulation_dof(art, self._solar_panel_joint)
-            return
-        elif self._solar_panel_dof != None:
-            return
+        return list(self._wheel_joint_names.get(side, []))
 
+    def get_joint_positions(self) -> dict[str, float]:
+        return dict(self._last_joint_positions)
+
+    def get_joint_velocities(self) -> dict[str, float]:
+        return dict(self._last_joint_velocities)
+
+    def get_joint_efforts(self) -> dict[str, float]:
+        return dict(self._last_joint_efforts)
+
+    def get_available_joint_names(self) -> list[str]:
+        if self.control.is_ready:
+            return list(self.control.joint_names)
+
+        return list(self._last_joint_positions.keys())
+
+    def _check_solar_panel_joint(self) -> None:
         if self._solar_panel_joint == "":
-            raise Exception("Solar panel joint is not specified. Please check your .yaml configuration file. 'solar_panel_joint' should be defined on the same level as 'robot_name'.")
+            raise Exception(
+                "Solar panel joint is not specified. "
+                "Please check your .yaml configuration file. "
+                "'solar_panel_joint' should be defined on the same level as 'robot_name'."
+            )
+
+        if not self._articulation_api_enabled:
+            raise RuntimeError(
+                f"Articulation API is not ready: {self.robot_path}. "
+                "Call update_articulation_api() from the simulation loop first."
+            )
+
+        if self._solar_panel_joint not in self.control.joint_name_to_index:
+            raise RuntimeError(
+                f"Solar panel joint '{self._solar_panel_joint}' was not found in articulation "
+                f"{self.robot_path}. Available joints: {self.control.joint_names}"
+            )
 
     def deploy_solar_panel(self):
-        self._init_solar_panel_dof()
-        self.dc.set_dof_position_target(self._solar_panel_dof, math.radians(0))
+        self._check_solar_panel_joint()
+        self.set_joint_positions({self._solar_panel_joint: math.radians(0)})
 
     def stow_solar_panel(self):
-        self._init_solar_panel_dof()
-        self.dc.set_dof_position_target(self._solar_panel_dof, math.radians(-80))
+        self._check_solar_panel_joint()
+        self.set_joint_positions({self._solar_panel_joint: math.radians(-80)})
 
-#TODO for v4: rethink which methods should be in RRG, what should be in Robot
-#TODO for v4: separate into a different file (very complex and lengthy classes)
+
+# TODO for v4: rethink which methods should be in RRG, what should be in Robot
+# TODO for v4: separate into a different file (very complex and lengthy classes)
 class RobotRigidGroup:
     """
     Class which deals with rigidprims and rigidprimview of a single robot.
     It is used to retrieve world pose, and contact forces, or apply force/torque.
     """
 
-    def __init__(self, root_path: str = "/Robots", robot_name: str = None, target_links: List[str] = None, base_link:str=None):
+    def __init__(
+        self, root_path: str = "/Robots", robot_name: str = None, target_links: List[str] = None, base_link: str = None
+    ):
         """
         Args:
             root_path (str): The root path of the robots.
@@ -545,7 +814,7 @@ class RobotRigidGroup:
         Initialize the rigidprims and rigidprimviews of the robot.
 
         Args:
-            world (World): A isaacsim.core.api.world.World object.
+            world (World): A Omni.isaac.core.world.World object.
         """
 
         self.dt = world.get_physics_dt()
@@ -568,7 +837,7 @@ class RobotRigidGroup:
         if not self.base_link:
             raise ValueError(
                 f"Robot '{self.robot_name}' is missing required 'base_link' in its YAML configuration. "
-                "Please add e.g. base_link: \"base_link\" under the robot's parameters."
+                'Please add e.g. base_link: "base_link" under the robot\'s parameters.'
             )
         # Use SingleXFormPrim instead of SingleRigidPrim for the base link.
         # SingleRigidPrim eagerly queries physics velocities in its constructor,
@@ -646,11 +915,16 @@ class RobotRigidGroup:
 
             # Convert back to (w, x, y, z) and store results
             quaternion_corrected = rotation_corrected.as_quat()
-            orientation_corrected = [quaternion_corrected[3], quaternion_corrected[0], quaternion_corrected[1], quaternion_corrected[2]]
+            orientation_corrected = [
+                quaternion_corrected[3],
+                quaternion_corrected[0],
+                quaternion_corrected[1],
+                quaternion_corrected[2],
+            ]
             positions[i, :] = position
             orientations[i, :] = orientation_corrected
         return positions, orientations
-    
+
     def get_pose_of_base_link(self) -> Tuple[list, list]:
         """
         Returns a pair of value representing the robot's pose, and orientation respectively, based on the base_link.
@@ -692,7 +966,7 @@ class RobotRigidGroup:
         n_links = len(self.target_links)
         contact_forces = np.zeros((n_links, 3))
         for i, prim_view in enumerate(self.prim_views):
-            contact_force = prim_view.get_net_contact_forces(dt = self.dt).squeeze()
+            contact_force = prim_view.get_net_contact_forces(dt=self.dt).squeeze()
             contact_forces[i, :] = contact_force
         return contact_forces
 

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -70,10 +70,6 @@ class RobotManager:
         Args:
             world (Usd.Stage): The usd stage scene.
         """
-        print("self.robot_parameters")
-
-        print(self.robot_parameters)
-
         self.add_robot(
             self.robot_parameters.usd_path,
             self.robot_parameters.robot_name,


### PR DESCRIPTION
## Summary

Refactors `robot.py` to replace the deprecated Isaac Dynamic Control API with the newer `SingleArticulation` / `ArticulationAction` based control and telemetry flow.

## Changes

- Added reusable articulation control and telemetry APIs.
- Updated robot joint position, velocity, and effort command paths.
- Added cached joint telemetry for positions, velocities, efforts, and wheel angles.
- Updated wheel and solar panel control to use the new articulation API.
- Added `update_articulation_api()` and reset invalidation handling.
- Updated ROS2/Yamcs simulation managers to update articulation state from the simulation loop.
- Fixed ROS reset callback/modification handling.

## Motivation

Dynamic Control is deprecated, and robot-level control/telemetry should not depend on transport-specific managers. This refactor moves articulation logic into reusable robot APIs and avoids direct Isaac physics reads from passive getters.

## Notes

```text
simulation loop
  -> world.step()
  -> robot.update_articulation_api()
  -> robot getters return cached telemetry
  -> commands use ArticulationAction
```