### PR TITLE
removed redundant info in headers, key line is __author__ for credit

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from omegaconf import DictConfig, OmegaConf, ListConfig
 from src.configurations import configFactory

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard, Junnosuke Kahamora, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/configurations/__init__.py
+++ b/src/configurations/__init__.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 """
 Configurations

--- a/src/configurations/auto_labeling_confs.py
+++ b/src/configurations/auto_labeling_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import dataclasses
 

--- a/src/configurations/environments.py
+++ b/src/configurations/environments.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import dataclasses
 import os

--- a/src/configurations/physics_confs.py
+++ b/src/configurations/physics_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import dataclasses

--- a/src/configurations/procedural_terrain_confs.py
+++ b/src/configurations/procedural_terrain_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import dataclasses
 from typing import Any, Union, List

--- a/src/configurations/rendering_confs.py
+++ b/src/configurations/rendering_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import dataclasses
 

--- a/src/configurations/robot_confs.py
+++ b/src/configurations/robot_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import os
 from dataclasses import dataclass, field

--- a/src/configurations/rock_generation_confs.py
+++ b/src/configurations/rock_generation_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import dataclasses
 

--- a/src/configurations/simulator_mode_enum.py
+++ b/src/configurations/simulator_mode_enum.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import Enum
 

--- a/src/configurations/stellar_engine_confs.py
+++ b/src/configurations/stellar_engine_confs.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import dataclasses
 import datetime

--- a/src/environments/__init__.py
+++ b/src/environments/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/environments/base_env.py
+++ b/src/environments/base_env.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import omni
 from pxr import Usd

--- a/src/environments/large_scale_lunar.py
+++ b/src/environments/large_scale_lunar.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from scipy.spatial.transform import Rotation as SSTR
 from typing import Dict, Tuple

--- a/src/environments/lunalab.py
+++ b/src/environments/lunalab.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple, Dict
 import numpy as np

--- a/src/environments/lunaryard.py
+++ b/src/environments/lunaryard.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Dict
 import os

--- a/src/environments/monitoring_cameras_manager.py
+++ b/src/environments/monitoring_cameras_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Dict
 import os

--- a/src/environments/rendering.py
+++ b/src/environments/rendering.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import carb

--- a/src/environments/rock_manager.py
+++ b/src/environments/rock_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from WorldBuilders.Types import *
 from WorldBuilders.Mixer import RequestMixer

--- a/src/environments/static_assets_manager.py
+++ b/src/environments/static_assets_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from pathlib import Path
 from typing import Dict

--- a/src/environments/stellar_engine_env_mixin.py
+++ b/src/environments/stellar_engine_env_mixin.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import math
 import os

--- a/src/environments/terrain_control_mixin.py
+++ b/src/environments/terrain_control_mixin.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Dict, TYPE_CHECKING
 

--- a/src/environments/utils.py
+++ b/src/environments/utils.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from pxr import UsdGeom, Gf
 import numpy as np

--- a/src/environments_wrappers/__init__.py
+++ b/src/environments_wrappers/__init__.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 
 def startSim(cfg: dict):

--- a/src/environments_wrappers/rate.py
+++ b/src/environments_wrappers/rate.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import time
 

--- a/src/environments_wrappers/ros2/__init__.py
+++ b/src/environments_wrappers/ros2/__init__.py
@@ -1,12 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = (
-    "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-)
-__license__ = "BSD-3-Clause"
-__version__ = "1.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 
 def enable_ros2(simulation_app, bridge_name="foxy", **kwargs) -> None:

--- a/src/environments_wrappers/ros2/base_wrapper_ros2.py
+++ b/src/environments_wrappers/ros2/base_wrapper_ros2.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 # System imports
 from typing import List, Tuple

--- a/src/environments_wrappers/ros2/largescale_ros2.py
+++ b/src/environments_wrappers/ros2/largescale_ros2.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 # Custom libs
 from src.environments_wrappers.ros2.base_wrapper_ros2 import ROS_BaseManager

--- a/src/environments_wrappers/ros2/lunalab_ros2.py
+++ b/src/environments_wrappers/ros2/lunalab_ros2.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "1.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 # Custom libs
 from src.environments_wrappers.ros2.base_wrapper_ros2 import ROS_BaseManager

--- a/src/environments_wrappers/ros2/lunaryard_ros2.py
+++ b/src/environments_wrappers/ros2/lunaryard_ros2.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 # Custom libs
 from src.environments_wrappers.ros2.base_wrapper_ros2 import ROS_BaseManager

--- a/src/environments_wrappers/ros2/robot_manager_ros2.py
+++ b/src/environments_wrappers/ros2/robot_manager_ros2.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Aleksa Stanivuk, Shamistan Karimov"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "1.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple
 

--- a/src/environments_wrappers/ros2/simulation_manager_ros2.py
+++ b/src/environments_wrappers/ros2/simulation_manager_ros2.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk, Shamistan Karimov"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import logging
 from threading import Thread

--- a/src/environments_wrappers/sdg/__init__.py
+++ b/src/environments_wrappers/sdg/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/environments_wrappers/sdg/lunalab_sdg.py
+++ b/src/environments_wrappers/sdg/lunalab_sdg.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 # System imports
 from scipy.spatial.transform import Rotation as SSTR

--- a/src/environments_wrappers/sdg/lunaryard_sdg.py
+++ b/src/environments_wrappers/sdg/lunaryard_sdg.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 # System imports
 from scipy.spatial.transform import Rotation as SSTR

--- a/src/environments_wrappers/sdg/simulation_manager_sdg.py
+++ b/src/environments_wrappers/sdg/simulation_manager_sdg.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.environments_wrappers.sdg.lunaryard_sdg import SDG_Lunaryard
 from src.environments_wrappers.sdg.lunalab_sdg import SDG_Lunalab

--- a/src/environments_wrappers/yamcs/simulation_manager_yamcs.py
+++ b/src/environments_wrappers/yamcs/simulation_manager_yamcs.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk, Shamistan Karimov, Bach Nguyen"
-__copyright__ = "Copyright 2026, JAOPS, AsteriaART/Artefacts"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import logging
 import time

--- a/src/labeling/__init__.py
+++ b/src/labeling/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard, Junnosuke Kahamora"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/labeling/auto_label.py
+++ b/src/labeling/auto_label.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kahamora"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple, Dict, Union
 import random, string

--- a/src/labeling/instancer.py
+++ b/src/labeling/instancer.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kahamora"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import numpy as np
 import omni

--- a/src/labeling/rep_utils.py
+++ b/src/labeling/rep_utils.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kahamora"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Any, Union, Dict
 import pandas as pd

--- a/src/mission_specific/husky/subsystems/husky_power_model.py
+++ b/src/mission_specific/husky/subsystems/husky_power_model.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/subsystems/husky_subsystems_handler.py
+++ b/src/mission_specific/husky/subsystems/husky_subsystems_handler.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/tmtc/camera_handler.py
+++ b/src/mission_specific/husky/tmtc/camera_handler.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/tmtc/enums.py
+++ b/src/mission_specific/husky/tmtc/enums.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/tmtc/husky_commander.py
+++ b/src/mission_specific/husky/tmtc/husky_commander.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/tmtc/husky_controller.py
+++ b/src/mission_specific/husky/tmtc/husky_controller.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/tmtc/husky_drive_handler.py
+++ b/src/mission_specific/husky/tmtc/husky_drive_handler.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/husky/tmtc/transmitter.py
+++ b/src/mission_specific/husky/tmtc/transmitter.py
@@ -1,8 +1,4 @@
 __author__ = "Amaan Javed"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "3.0.0"
-__status__ = "development"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
 

--- a/src/mission_specific/pragyaan/subsystems/neutron_spectrometer_model.py
+++ b/src/mission_specific/pragyaan/subsystems/neutron_spectrometer_model.py
@@ -1,10 +1,6 @@
 __author__ = "Louis Burtz, Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import math
 import random

--- a/src/mission_specific/pragyaan/subsystems/pragyaan_obc_metrics_model.py
+++ b/src/mission_specific/pragyaan/subsystems/pragyaan_obc_metrics_model.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import Enum
 

--- a/src/mission_specific/pragyaan/subsystems/pragyaan_power_model.py
+++ b/src/mission_specific/pragyaan/subsystems/pragyaan_power_model.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import Enum
 from typing import Tuple

--- a/src/mission_specific/pragyaan/subsystems/pragyaan_robot_enums.py
+++ b/src/mission_specific/pragyaan/subsystems/pragyaan_robot_enums.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import IntEnum
 

--- a/src/mission_specific/pragyaan/subsystems/pragyaan_subsystems_handler.py
+++ b/src/mission_specific/pragyaan/subsystems/pragyaan_subsystems_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.mission_specific.pragyaan.subsystems.neutron_spectrometer_model import NeutronSpectrometerModel
 from src.mission_specific.pragyaan.subsystems.pragyaan_obc_metrics_model import PragyaanObcMetricsModel

--- a/src/mission_specific/pragyaan/subsystems/pragyaan_thermal_model.py
+++ b/src/mission_specific/pragyaan/subsystems/pragyaan_thermal_model.py
@@ -1,10 +1,6 @@
 __author__ = "Louis Burtz, Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.subsystems.robot_physics_models.thermal_model import ThermalModel
 from dataclasses import dataclass

--- a/src/mission_specific/pragyaan/tmtc/camera_handler.py
+++ b/src/mission_specific/pragyaan/tmtc/camera_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import StrEnum
 from src.environments.monitoring_cameras_manager import MonitoringCamerasManager

--- a/src/mission_specific/pragyaan/tmtc/commander.py
+++ b/src/mission_specific/pragyaan/tmtc/commander.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.mission_specific.pragyaan.tmtc.enums import PragyaanCameraResolution, PragyaanYamcsArguments
 from src.subsystems.device import CommonDevice, HealthState, PowerState

--- a/src/mission_specific/pragyaan/tmtc/payload_handler.py
+++ b/src/mission_specific/pragyaan/tmtc/payload_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from PIL import Image, ImageDraw, ImageFont
 import os

--- a/src/mission_specific/pragyaan/tmtc/pragyaan_controller.py
+++ b/src/mission_specific/pragyaan/tmtc/pragyaan_controller.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.mission_specific.pragyaan.tmtc.camera_handler import PragyaanCameraHandler
 from src.mission_specific.pragyaan.tmtc.commander import PragyaanCommander

--- a/src/mission_specific/pragyaan/tmtc/transmitter.py
+++ b/src/mission_specific/pragyaan/tmtc/transmitter.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.environments.utils import transform_orientation_into_xyz
 import math

--- a/src/physics/__init__.py
+++ b/src/physics/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/physics/physics_scene.py
+++ b/src/physics/physics_scene.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.configurations.physics_confs import PhysicsSceneConf
 

--- a/src/physics/terramechanics_parameters.py
+++ b/src/physics/terramechanics_parameters.py
@@ -1,10 +1,6 @@
 __author__ = "Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from dataclasses import dataclass
 import math

--- a/src/physics/terramechanics_solver.py
+++ b/src/physics/terramechanics_solver.py
@@ -1,10 +1,6 @@
 __author__ = "Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import numpy as np
 import torch

--- a/src/robots/__init__.py
+++ b/src/robots/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/robots/articulation_control.py
+++ b/src/robots/articulation_control.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 __author__ = "Shamistan Karimov, Bach Nguyen"
-__copyright__ = "Copyright 2025-26, JAOPS, AsteriaART/Artefacts"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import logging
 import time

--- a/src/robots/articulation_telemetry.py
+++ b/src/robots/articulation_telemetry.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 __author__ = "Shamistan Karimov, Bach Nguyen"
-__copyright__ = "Copyright 2025-26, JAOPS, AsteriaART/Artefacts"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import logging
 import time

--- a/src/robots/robot.py
+++ b/src/robots/robot.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara, Aleksa Stanivuk, Shamistan Karimov"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import math
 import os

--- a/src/stellar/__init__.py
+++ b/src/stellar/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/stellar/stellar_engine.py
+++ b/src/stellar/stellar_engine.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.configurations.stellar_engine_confs import StellarEngineConf
 from scipy.spatial.transform import Rotation as SSTR

--- a/src/subsystems/device.py
+++ b/src/subsystems/device.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import IntEnum, StrEnum
 from typing import Tuple

--- a/src/subsystems/robot_enums.py
+++ b/src/subsystems/robot_enums.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import IntEnum
 

--- a/src/subsystems/robot_physics_models/obc_metrics_model.py
+++ b/src/subsystems/robot_physics_models/obc_metrics_model.py
@@ -1,10 +1,6 @@
 __author__ = "Louis Burtz, Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import random
 import time

--- a/src/subsystems/robot_physics_models/power_model.py
+++ b/src/subsystems/robot_physics_models/power_model.py
@@ -1,10 +1,6 @@
 __author__ = "Louis Burtz, Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 """Simple power model with battery, solar charging, and device loads."""
 

--- a/src/subsystems/robot_physics_models/radio_model.py
+++ b/src/subsystems/robot_physics_models/radio_model.py
@@ -1,10 +1,6 @@
 __author__ = "Louis Burtz, Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 """Basic RSSI model relating rover/lander separation to signal strength."""
 

--- a/src/subsystems/robot_physics_models/robot_physics_model.py
+++ b/src/subsystems/robot_physics_models/robot_physics_model.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2026, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from abc import ABC, abstractmethod
 from typing import Dict, Any

--- a/src/subsystems/robot_physics_models/thermal_model.py
+++ b/src/subsystems/robot_physics_models/thermal_model.py
@@ -1,10 +1,6 @@
 __author__ = "Louis Burtz, Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 """Basic thermal model for a six-faced box with a single interior node."""
 

--- a/src/subsystems/robot_subsystems_handler.py
+++ b/src/subsystems/robot_subsystems_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from abc import ABC, abstractmethod
 from enum import Enum

--- a/src/terrain_management/__init__.py
+++ b/src/terrain_management/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/terrain_management/deformation_engine.py
+++ b/src/terrain_management/deformation_engine.py
@@ -1,10 +1,6 @@
 __author__ = "Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple
 from matplotlib import pyplot as plt

--- a/src/terrain_management/large_scale_terrain/__init__.py
+++ b/src/terrain_management/large_scale_terrain/__init__.py
@@ -1,7 +1,3 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"

--- a/src/terrain_management/large_scale_terrain/collider_builder.py
+++ b/src/terrain_management/large_scale_terrain/collider_builder.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import numpy as np

--- a/src/terrain_management/large_scale_terrain/collider_manager.py
+++ b/src/terrain_management/large_scale_terrain/collider_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple, List
 import dataclasses

--- a/src/terrain_management/large_scale_terrain/crater_database.py
+++ b/src/terrain_management/large_scale_terrain/crater_database.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from scipy.interpolate import CubicSpline
 from typing import Tuple, List

--- a/src/terrain_management/large_scale_terrain/crater_distribution.py
+++ b/src/terrain_management/large_scale_terrain/crater_distribution.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from scipy.interpolate import CubicSpline
 from matplotlib import pyplot as plt

--- a/src/terrain_management/large_scale_terrain/crater_generation.py
+++ b/src/terrain_management/large_scale_terrain/crater_generation.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from scipy.ndimage import rotate
 from typing import Tuple, List

--- a/src/terrain_management/large_scale_terrain/geometry_clipmaps.py
+++ b/src/terrain_management/large_scale_terrain/geometry_clipmaps.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import dataclasses

--- a/src/terrain_management/large_scale_terrain/geometry_clipmaps_manager.py
+++ b/src/terrain_management/large_scale_terrain/geometry_clipmaps_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.terrain_management.large_scale_terrain.geometry_clipmaps import (
     GeometryClipmapConf,

--- a/src/terrain_management/large_scale_terrain/geometry_clipmaps_numba.py
+++ b/src/terrain_management/large_scale_terrain/geometry_clipmaps_numba.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import numba as nb
 import numpy as np

--- a/src/terrain_management/large_scale_terrain/geometry_clipmaps_warp.py
+++ b/src/terrain_management/large_scale_terrain/geometry_clipmaps_warp.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import warp as wp
 

--- a/src/terrain_management/large_scale_terrain/high_resolution_DEM_generator.py
+++ b/src/terrain_management/large_scale_terrain/high_resolution_DEM_generator.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple, Dict
 import numpy as np

--- a/src/terrain_management/large_scale_terrain/high_resolution_DEM_workers.py
+++ b/src/terrain_management/large_scale_terrain/high_resolution_DEM_workers.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import multiprocessing.managers
 from typing import List, Tuple, Dict

--- a/src/terrain_management/large_scale_terrain/map_manager.py
+++ b/src/terrain_management/large_scale_terrain/map_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import dataclasses

--- a/src/terrain_management/large_scale_terrain/nested_geometry_clipmaps_manager.py
+++ b/src/terrain_management/large_scale_terrain/nested_geometry_clipmaps_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import dataclasses

--- a/src/terrain_management/large_scale_terrain/pxr_utils.py
+++ b/src/terrain_management/large_scale_terrain/pxr_utils.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import os
 import logging

--- a/src/terrain_management/large_scale_terrain/rock_database.py
+++ b/src/terrain_management/large_scale_terrain/rock_database.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple, List
 import numpy as np

--- a/src/terrain_management/large_scale_terrain/rock_distribution.py
+++ b/src/terrain_management/large_scale_terrain/rock_distribution.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from matplotlib import pyplot as plt
 from typing import List, Tuple

--- a/src/terrain_management/large_scale_terrain/rock_manager.py
+++ b/src/terrain_management/large_scale_terrain/rock_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple, Dict, Union
 import numpy as np

--- a/src/terrain_management/large_scale_terrain/utils.py
+++ b/src/terrain_management/large_scale_terrain/utils.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from scipy.interpolate import CubicSpline
 from typing import Tuple

--- a/src/terrain_management/large_scale_terrain_manager.py
+++ b/src/terrain_management/large_scale_terrain_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import Tuple
 import dataclasses

--- a/src/terrain_management/terrain_generation.py
+++ b/src/terrain_management/terrain_generation.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from scipy.interpolate import CubicSpline
 from matplotlib import pyplot as plt

--- a/src/terrain_management/terrain_manager.py
+++ b/src/terrain_management/terrain_manager.py
@@ -1,10 +1,6 @@
 __author__ = "Antoine Richard, Junnosuke Kamohara"
-__copyright__ = "Copyright 2023-26, JAOPS, Space Robotics Lab, SnT, University of Luxembourg, SpaceR"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from typing import List, Tuple
 import numpy as np

--- a/src/tmtc/commands_handler.py
+++ b/src/tmtc/commands_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 import time
 import omni.kit.app
 

--- a/src/tmtc/drive_handler.py
+++ b/src/tmtc/drive_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.subsystems.device import CommonDevice, HealthState, PowerState
 import math

--- a/src/tmtc/images_handler.py
+++ b/src/tmtc/images_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import omni.kit.app
 import os

--- a/src/tmtc/intervals_handler.py
+++ b/src/tmtc/intervals_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from enum import Enum
 import omni.timeline

--- a/src/tmtc/obc_handler.py
+++ b/src/tmtc/obc_handler.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 import omni.kit.app
 from src.subsystems.robot_enums import ObcState

--- a/src/tmtc/yamcs_TMTC.py
+++ b/src/tmtc/yamcs_TMTC.py
@@ -1,10 +1,6 @@
 __author__ = "Aleksa Stanivuk"
-__copyright__ = "Copyright 2025-26, JAOPS"
-__license__ = "BSD-3-Clause"
-__version__ = "2.0.0"
 __maintainer__ = "Louis Burtz"
 __email__ = "ljburtz@jaops.com"
-__status__ = "development"
 
 from src.tmtc.commands_handler import CommandsHandler
 from src.tmtc.drive_handler import DriveHandler


### PR DESCRIPTION
copyright and license are already at the license file at the root of the repo
version and status are tracked on github releases
these tags are for old style doc parsers anyways. keeping just for the good purpose of each contributor writing their name in the __author__ field!