### PR TITLE
FIx atomic_min/atomic_max

### DIFF
--- a/src/terrain_management/large_scale_terrain/geometry_clipmaps_warp.py
+++ b/src/terrain_management/large_scale_terrain/geometry_clipmaps_warp.py
@@ -31,10 +31,10 @@ def _preprocess(
     tid = wp.tid()
     x[tid] = points[tid][0] / mpp + coord[0]
     y[tid] = points[tid][1] / mpp + coord[1]
-    x[tid] = wp.atomic_min(x, tid, dem_shape[0] - 1.0)
-    y[tid] = wp.atomic_min(y, tid, dem_shape[1] - 1.0)
-    x[tid] = wp.atomic_max(x, tid, 0.0)
-    y[tid] = wp.atomic_max(y, tid, 0.0)
+    _ = wp.atomic_min(x, tid, dem_shape[0] - 1.0)
+    _ = wp.atomic_min(y, tid, dem_shape[1] - 1.0)
+    _ = wp.atomic_max(x, tid, 0.0)
+    _ = wp.atomic_max(y, tid, 0.0)
 
 
 @wp.func


### PR DESCRIPTION
`atomic_min` and `atomic_max` change the variable in place(https://nvidia.github.io/warp/v1.15/language_reference/_generated/warp.atomic_min.html). 

The return is just the old value. 

Extra details:

The old implementation was working only because of a bug in the warp library fixed with https://github.com/NVIDIA/warp/commit/4f07ad040cc8926b0fad89cbe2c9c3b4bb0b0597 . So the atomic_min/max were always designed to return the old value but they were returning the new one only because of the bug. 

